### PR TITLE
site migration: switch internal Location lookups from stationName to …

### DIFF
--- a/backend/cron_jobs/cycleCountReportCron.js
+++ b/backend/cron_jobs/cycleCountReportCron.js
@@ -18,12 +18,12 @@ const updateCycleCountCSO = async () => {
 
     // 1. Fetch active monitoring store list from Mongo to handle specific timezones
     const locations = await Location.find({
-      stationName: { $nin: excludedSites },
+      site: { $nin: excludedSites },
       type: "store"
     }).lean();
 
     for (const loc of locations) {
-      const { stationName: siteName, timezone, _id: siteMongoId } = loc;
+      const { site: siteName, timezone, _id: siteMongoId } = loc;
       if (!timezone || !siteMongoId) continue;
 
       const mongoSiteIdStr = siteMongoId.toString();

--- a/backend/cron_jobs/productCategoryMappingCron.js
+++ b/backend/cron_jobs/productCategoryMappingCron.js
@@ -299,7 +299,7 @@ async function syncCategoryProductMapping() {
       if (!site) continue;
 
       // find Location to get station code (csoCode)
-      const loc = await Location.findOne({ stationName: site }).lean();
+      const loc = await Location.findOne({ site }).lean();
       if (!loc || !loc.csoCode) {
         console.log(`No Location.csoCode found for site '${site}', skipping inactive check for this site.`);
         continue;

--- a/backend/routes/audit/auditTemplateRoutes.js
+++ b/backend/routes/audit/auditTemplateRoutes.js
@@ -880,7 +880,7 @@ router.post('/instance', async (req, res) => {
 
                   if (match.text === "Station Manager") {
                     // 🧩 NEW: Fetch Location to get the managerEmails array
-                    const location = await Location.findOne({ stationName: site });
+                    const location = await Location.findOne({ site });
 
                     if (location?.managerEmails && location.managerEmails.length > 0) {
                       // Add all manager emails to the list

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -142,7 +142,7 @@ router.post("/register", async (req, res) => {
 //     // Fetch location and timezone
 //     let timezone = null;
 //     if (user.stationName) {
-//       const location = await Location.findOne({ stationName: user.stationName });
+//       const location = await Location.findOne({ site: user.site ?? user.stationName });
 //       timezone = location?.timezone || null;
 //     }
 
@@ -203,7 +203,7 @@ router.post("/login", async (req, res) => {
     // Fetch location & timezone
     let timezone = null;
     if (user.stationName) {
-      const location = await Location.findOne({ stationName: user.stationName });
+      const location = await Location.findOne({ site: user.site ?? user.stationName });
       timezone = location?.timezone || null;
     }
 
@@ -394,7 +394,7 @@ router.post("/refresh-token", async (req, res) => {
     const mergedPermissions = await getMergedPermissionsTreeArray(user);
     let timezone = null;
     if (user.stationName) {
-      const location = await Location.findOne({ stationName: user.stationName });
+      const location = await Location.findOne({ site: user.site ?? user.stationName });
       timezone = location?.timezone || null;
     }
 

--- a/backend/routes/cashRecRoutes.js
+++ b/backend/routes/cashRecRoutes.js
@@ -676,7 +676,7 @@ router.get('/entries', async (req, res) => {
     // Compute adjusted over/short for lottery sites
     let adjustedOverShort = null
     try {
-      const location = await Location.findOne({ stationName: site }).lean()
+      const location = await Location.findOne({ site }).lean()
       if (location?.sellsLottery) {
         const lotteryDoc = await Lottery.findOne({ site, date }).lean()
         if (lotteryDoc) {

--- a/backend/routes/cashSummaryNewRoutes.js
+++ b/backend/routes/cashSummaryNewRoutes.js
@@ -236,7 +236,7 @@ router.get('/voided-transactions-details', async (req, res) => {
       return res.status(400).json({ error: 'Site and Date are required' });
     }
 
-    const location = await Location.findOne({ stationName: site });
+    const location = await Location.findOne({ site });
     if (!location || !location.csoCode) {
       return res.status(404).json({ error: 'Location or CSO Code not found' });
     }
@@ -286,7 +286,7 @@ router.get('/over-short', async (req, res) => {
     if (!site) return res.status(400).json({ error: 'site is required' });
 
     // 1️⃣ Check if site sells lottery
-    const location = await Location.findOne({ stationName: site }).lean();
+    const location = await Location.findOne({ site }).lean();
     const sellsLottery = location?.sellsLottery || false;
     const csoCode = location?.csoCode;
 
@@ -567,7 +567,7 @@ router.get('/payables-comparison', async (req, res) => {
     const { site } = req.query;
     if (!site) return res.status(400).json({ error: 'site is required' });
 
-    const locationInfo = await Location.findOne({ stationName: site }).lean();
+    const locationInfo = await Location.findOne({ site }).lean();
     const sellsLottery = locationInfo?.sellsLottery || false;
 
     const end = new Date();
@@ -1045,7 +1045,7 @@ router.post('/submit/to/safesheet', async (req, res) => {
     let isManitoba = false;
     try {
       // Accessing your location database directly on the backend
-      const loc = await Location.findOne({ stationName: site }).lean();
+      const loc = await Location.findOne({ site }).lean();
       isManitoba = loc?.province?.trim().toLowerCase() === 'manitoba';
     } catch (locErr) {
       console.error('Backend location lookup for province failed:', locErr?.message || locErr);
@@ -1358,7 +1358,7 @@ router.get('/payouts-check', async (req, res) => {
     const start = new Date(date); start.setUTCHours(0, 0, 0, 0)
     const end = new Date(date); end.setUTCHours(23, 59, 59, 999)
 
-    const location = await Location.findOne({ stationName: site }).lean()
+    const location = await Location.findOne({ site }).lean()
 
     const [shiftAgg] = await CashSummary.aggregate([
       { $match: { site, date: { $gte: start, $lte: end } } },
@@ -1389,7 +1389,7 @@ router.get('/ar-check-range', async (req, res) => {
   if (!site || !from || !to) return res.status(400).json({ error: 'site, from, and to are required' })
 
   try {
-    const location = await Location.findOne({ stationName: site }, { timezone: 1 }).lean()
+    const location = await Location.findOne({ site }, { timezone: 1 }).lean()
     const tz = location?.timezone || 'America/Toronto'
 
     const csStart = new Date(from); csStart.setUTCHours(0, 0, 0, 0)
@@ -1467,7 +1467,7 @@ router.get('/ar-check', async (req, res) => {
     // query using the site's local timezone day boundaries, not UTC midnight.
     // Fallback branch covers PO docs (and all Kardpoll docs) that predate the
     // dateStr migration and don't have a dateStr field yet.
-    const location = await Location.findOne({ stationName: site }, { timezone: 1 }).lean()
+    const location = await Location.findOne({ site }, { timezone: 1 }).lean()
     const tz = location?.timezone || 'America/Toronto'
     const txStart = DateTime.fromISO(date, { zone: tz }).startOf('day').toJSDate()
     const txEnd = DateTime.fromISO(date, { zone: tz }).endOf('day').toJSDate()

--- a/backend/routes/cycleCountRoutes.js
+++ b/backend/routes/cycleCountRoutes.js
@@ -79,7 +79,7 @@ router.get('/daily-items', async (req, res) => {
     if (!site) return res.status(400).json({ message: "site is required" });
 
     // Get location object to determine the site's timezone
-    const location = await Location.findOne({ stationName: site.toString().trim() });
+    const location = await Location.findOne({ site: site.toString().trim() });
     const siteTimezone = location?.timezone || 'UTC';
 
     // Compare user timezone with site timezone
@@ -345,7 +345,7 @@ router.get('/daily-items-v2', async (req, res) => {
 
     // 1. Get Site & Categories from Mongo
     const [location, mongoCategories] = await Promise.all([
-      Location.findOne({ stationName: site }),
+      Location.findOne({ site }),
       ProductCategory.find({}).lean()
     ]);
 
@@ -414,7 +414,7 @@ router.get('/item-bk', async (req, res) => {
 
     // 1. Get Site details and Mongo categories simultaneously
     const [location, mongoCategories] = await Promise.all([
-      Location.findOne({ stationName: site }),
+      Location.findOne({ site }),
       ProductCategory.find({}).lean()
     ]);
 
@@ -601,7 +601,7 @@ router.get('/groups/preview-items', async (req, res) => {
 
     // 1. Resolve Site details and Mongo categories concurrently
     const [location, mongoCategories] = await Promise.all([
-      Location.findOne({ stationName: site }),
+      Location.findOne({ site }),
       ProductCategory.find({}).lean()
     ]);
 
@@ -666,7 +666,7 @@ router.get('/instances', async (req, res) => {
       return res.status(400).json({ message: "Site parameter is required" });
     }
 
-    const location = await Location.findOne({ stationName: site });
+    const location = await Location.findOne({ site });
     if (!location) {
       return res.status(404).json({ message: `Location '${site}' not found` });
     }
@@ -712,7 +712,7 @@ router.get('/schedules/check-date', async (req, res) => {
       return res.status(400).json({ message: "Site and date string are required" });
     }
 
-    const location = await Location.findOne({ stationName: site });
+    const location = await Location.findOne({ site });
     if (!location) {
       return res.status(404).json({ message: "Location structure not found" });
     }
@@ -1063,7 +1063,7 @@ router.post('/finalize-and-sync', async (req, res) => {
     }
 
     // 1. Locate the structural location profile context via matching station name string values
-    const locationDoc = await Location.findOne({ stationName: siteName }).lean();
+    const locationDoc = await Location.findOne({ site: siteName }).lean();
     if (!locationDoc) {
       return res.status(404).json({ 
         success: false, 
@@ -1113,7 +1113,7 @@ router.post('/schedules/create', async (req, res) => {
     }
 
     // Resolve site context to grab Mongo ID mapping target
-    const location = await Location.findOne({ stationName: site });
+    const location = await Location.findOne({ site });
     if (!location) {
       return res.status(404).json({ message: "Selected location context not recognized" });
     }
@@ -1856,7 +1856,7 @@ router.get('/v2/daily-counts', async (req, res) => {
     }
     const db = getPg();
 
-    const locationDoc = await Location.findOne({ stationName: site }).lean();
+    const locationDoc = await Location.findOne({ site }).lean();
     if (!locationDoc) {
       return res.status(404).json({ success: false, message: `Location profile not found for site: ${site}` });
     }
@@ -1950,7 +1950,7 @@ router.get("/daily-report", async (req, res) => {
 
   try {
     // 1. Resolve the text site name to its MongoDB ID string reference
-    const locationDoc = await Location.findOne({ stationName: site }).lean();
+    const locationDoc = await Location.findOne({ site }).lean();
     if (!locationDoc) {
       return res.status(404).json({ success: false, message: `Location profile not found for site: ${site}` });
     }
@@ -2429,7 +2429,7 @@ router.get('/search', async (req, res) => {
 
     // 1. Resolve the human-readable site name to its master Mongo ID string
     const locationDoc = await Location.findOne({
-      stationName: site
+      site
     }).lean();
 
     // console.log(`Resolved location for site "${site}":`, locationDoc);

--- a/backend/routes/fuelRecRoutes.js
+++ b/backend/routes/fuelRecRoutes.js
@@ -227,7 +227,7 @@ router.post('/request-again', async (req, res) => {
 
   try {
     const location = await Location.findOne(
-      { stationName: site },
+      { site },
       { email: 1, stationName: 1, managerEmails: 1 }
     ).lean();
 

--- a/backend/routes/kardpollTransactions.js
+++ b/backend/routes/kardpollTransactions.js
@@ -86,7 +86,7 @@ router.get("/", async (req, res) => {
   }
 
   if (stationName) {
-    const locationRecord = await Location.findOne({ stationName: stationName });
+    const locationRecord = await Location.findOne({ site: stationName });
     if (locationRecord) {
       filter.stationName = locationRecord.stationName;
     } else {

--- a/backend/routes/location.js
+++ b/backend/routes/location.js
@@ -213,7 +213,7 @@ router.post("/check-code", async (req, res) => {
       return res.status(400).json({ error: "Missing location or code" });
     }
 
-    const locationDoc = await Location.findOne({ stationName: location }).lean();
+    const locationDoc = await Location.findOne({ site: location }).lean();
 
     if (!locationDoc) {
       return res.status(404).json({ error: "Location not found" });

--- a/backend/routes/purchaseOrder.js
+++ b/backend/routes/purchaseOrder.js
@@ -247,7 +247,7 @@ router.put("/:id", express.json(), async (req, res) => {
     }
 
     if (updates.requestReceipt === true) {
-      Location.findOne({ stationName: updatedOrder.stationName }, 'email stationName').lean()
+      Location.findOne({ site: updatedOrder.site ?? updatedOrder.stationName }, 'email stationName').lean()
         .then(location => {
           if (!location?.email) return
           const redirectUrl = `https://app.gen7fuel.com/po/list`

--- a/backend/routes/salesRoutes.js
+++ b/backend/routes/salesRoutes.js
@@ -214,7 +214,7 @@ router.post('/refresh-dashboard-cache', async (req, res) => {
     const { site } = req.query;
 
     if (site) {
-      const location = await Location.findOne({ stationName: site }).lean();
+      const location = await Location.findOne({ site }).lean();
       if (!location) return res.status(404).json({ error: "Site not found" });
       await refreshSiteCache(location.stationName, location.csoCode);
       return res.json({ message: `Cache refreshed for ${site}` });

--- a/backend/routes/writeOffRoutes.js
+++ b/backend/routes/writeOffRoutes.js
@@ -305,7 +305,7 @@ router.post('/', async (req, res) => {
     //   }
     // });
     // 8. Fetch Location for Manager Emails
-    const location = await Location.findOne({ stationName: site });
+    const location = await Location.findOne({ site });
 
     // 🧩 Logic: Fallback to store email if manager list is empty
     let storeTo = "grayson@gen7fuel.com"; // Absolute fallback
@@ -503,7 +503,7 @@ router.patch('/:id/items/:itemId', async (req, res) => {
 //     // 2. Fetch Location for CSO (Only if not BT)
 //     let csoLink = null;
 //     if (!isBT) {
-//       const location = await Location.findOne({ stationName: list.site });
+//       const location = await Location.findOne({ site: list.site });
 //       const csoCode = location?.csoCode || '0';
 //       const dateObj = new Date(list.createdAt);
 //       const formattedDate = dateObj.toLocaleDateString('en-US', {
@@ -558,7 +558,7 @@ router.patch('/:id/finalize', async (req, res) => {
     // 2. Fetch Location for CSO Link (Only if not Bistro)
     let csoLink = "";
     if (!isBT) {
-      const location = await Location.findOne({ stationName: list.site });
+      const location = await Location.findOne({ site: list.site });
       const csoCode = location?.csoCode || '0';
       const dateObj = new Date(list.createdAt);
       const formattedDate = dateObj.toLocaleDateString('en-US', {

--- a/backend/utils/eodReportWavers.js
+++ b/backend/utils/eodReportWavers.js
@@ -301,7 +301,7 @@ async function generateEodReportPdf({ site, date, isManitoba = false }) {
   const start = new Date(yy, mm - 1, dd, 0, 0, 0, 0);
   const end = new Date(yy, mm - 1, dd + 1, 0, 0, 0, 0);
 
-  const locationDoc = await Location.findOne({ stationName: site }).lean();
+  const locationDoc = await Location.findOne({ site }).lean();
   const sellsLottery = locationDoc?.sellsLottery === true;
   const csoCode = locationDoc?.csoCode;
 


### PR DESCRIPTION
…site

Now that site is backfilled and kept in sync everywhere, the ~30 internal Location.findOne/find({ stationName }) joins across routes and cron jobs can safely query by site instead, matching the majority naming convention used throughout the rest of the app.