### PR TITLE
Add custom quick-select button labels; add Jocko Point to no-PO-numbe…

### DIFF
--- a/backend/__tests__/arCustomer.test.js
+++ b/backend/__tests__/arCustomer.test.js
@@ -79,6 +79,30 @@ describe('ArCustomer — quickSelectSites', () => {
     expect(err?.errors['quickSelectSites.0.stationName']).toBeDefined()
   })
 
+  it('defaults label to an empty string when omitted', () => {
+    const doc = new ArCustomer(base({ quickSelectSites: [{ stationName: 'Walpole', order: 0 }] }))
+    expect(doc.quickSelectSites[0].label).toBe('')
+  })
+
+  it('accepts a custom label and trims it', () => {
+    const doc = new ArCustomer(base({
+      quickSelectSites: [{ stationName: 'Walpole', order: 0, label: '  Three Fires  ' }],
+    }))
+    expect(doc.validateSync()).toBeUndefined()
+    expect(doc.quickSelectSites[0].label).toBe('Three Fires')
+  })
+
+  it('supports independent labels per site entry', () => {
+    const doc = new ArCustomer(base({
+      quickSelectSites: [
+        { stationName: 'Walpole', order: 0, label: 'Three Fires' },
+        { stationName: 'Rankin', order: 0 },
+      ],
+    }))
+    expect(doc.quickSelectSites[0].label).toBe('Three Fires')
+    expect(doc.quickSelectSites[1].label).toBe('')
+  })
+
   // These use the async .validate() (not .validateSync()) because the
   // per-entry site <- stationName sync runs in a pre('validate') hook that
   // only fires under the async validate path.

--- a/backend/models/ArCustomer.js
+++ b/backend/models/ArCustomer.js
@@ -14,6 +14,11 @@ const ArCustomerSchema = new mongoose.Schema({
     stationName: { type: String, required: true, trim: true },
     site:        { type: String }, // Additive alias of stationName, auto-synced
     order:       { type: Number, default: 0 },
+    // Optional short text for the PO form's quick-select button. Falls back to
+    // the customer's own first name word (see po/index.tsx firstWord()) when
+    // blank — only needed when that default doesn't read well (e.g. a legal
+    // name like "Three fires development corporation" wanting "Three Fires").
+    label:       { type: String, trim: true, default: '' },
     _id: false,
   }],
 }, { timestamps: true })

--- a/backend/routes/arCustomerRoutes.js
+++ b/backend/routes/arCustomerRoutes.js
@@ -23,12 +23,16 @@ router.get('/quick-select', async (req, res) => {
       .select('name fleetCardNumber quickSelectSites')
 
     const result = customers
-      .map((c) => ({
-        _id: c._id,
-        name: c.name,
-        fleetCardNumber: c.fleetCardNumber || '',
-        order: c.quickSelectSites.find((s) => s.stationName === stationName)?.order ?? 0,
-      }))
+      .map((c) => {
+        const entry = c.quickSelectSites.find((s) => s.stationName === stationName)
+        return {
+          _id: c._id,
+          name: c.name,
+          fleetCardNumber: c.fleetCardNumber || '',
+          label: entry?.label || '',
+          order: entry?.order ?? 0,
+        }
+      })
       .sort((a, b) => a.order - b.order)
 
     res.json(result)
@@ -115,7 +119,7 @@ router.post('/sync', async (req, res) => {
 // POST /:id/quick-select — add this customer as a quick-select button for a site
 router.post('/:id/quick-select', async (req, res) => {
   try {
-    const { stationName } = req.body
+    const { stationName, label } = req.body
     if (!stationName) return res.status(400).json({ error: 'stationName is required' })
 
     const customer = await ArCustomer.findById(req.params.id)
@@ -132,9 +136,28 @@ router.post('/:id/quick-select', async (req, res) => {
       return entry ? Math.max(max, entry.order) : max
     }, -1)
 
-    customer.quickSelectSites.push({ stationName, order: maxOrder + 1 })
+    customer.quickSelectSites.push({ stationName, order: maxOrder + 1, label: (label || '').trim() })
     await customer.save()
     res.status(201).json(customer)
+  } catch (error) {
+    res.status(500).json({ error: error.message })
+  }
+})
+
+// PUT /:id/quick-select/label — set/clear this customer's quick-select button
+// text for a site, overriding the default (first word of the customer's name)
+router.put('/:id/quick-select/label', async (req, res) => {
+  try {
+    const { stationName, label } = req.body
+    if (!stationName) return res.status(400).json({ error: 'stationName is required' })
+
+    const customer = await ArCustomer.findOneAndUpdate(
+      { _id: req.params.id, 'quickSelectSites.stationName': stationName },
+      { $set: { 'quickSelectSites.$.label': (label || '').trim() } },
+      { new: true }
+    )
+    if (!customer) return res.status(404).json({ error: 'Customer or quick-select entry not found' })
+    res.json(customer)
   } catch (error) {
     res.status(500).json({ error: error.message })
   }
@@ -192,12 +215,16 @@ router.put('/quick-select/move', async (req, res) => {
     const customers = await ArCustomer.find({ 'quickSelectSites.stationName': stationName })
       .select('name fleetCardNumber quickSelectSites')
     const result = customers
-      .map((c) => ({
-        _id: c._id,
-        name: c.name,
-        fleetCardNumber: c.fleetCardNumber || '',
-        order: c.quickSelectSites.find((s) => s.stationName === stationName)?.order ?? 0,
-      }))
+      .map((c) => {
+        const entry = c.quickSelectSites.find((s) => s.stationName === stationName)
+        return {
+          _id: c._id,
+          name: c.name,
+          fleetCardNumber: c.fleetCardNumber || '',
+          label: entry?.label || '',
+          order: entry?.order ?? 0,
+        }
+      })
       .sort((a2, b2) => a2.order - b2.order)
     res.json(result)
   } catch (error) {

--- a/frontend/src/routes/_navbarLayout/__tests__/po.test.tsx
+++ b/frontend/src/routes/_navbarLayout/__tests__/po.test.tsx
@@ -355,7 +355,7 @@ describe('PO Form — index.tsx', () => {
     }, { timeout: 5000 })
   })
 
-  it.each(['Rankin', 'Sarnia', 'Walpole'])('does not render the Number section or OTP input for site "%s"', async (site) => {
+  it.each(['Rankin', 'Sarnia', 'Walpole', 'Jocko Point'])('does not render the Number section or OTP input for site "%s"', async (site) => {
     mockStore.stationName = site
     renderWithSuspense(<POForm />)
 
@@ -367,7 +367,7 @@ describe('PO Form — index.tsx', () => {
     expect(screen.queryByTestId('otp-input')).not.toBeInTheDocument()
   })
 
-  it.each(['Rankin', 'Sarnia', 'Walpole'])('does not auto-fill a fleet card from quick-select on site "%s"', async (site) => {
+  it.each(['Rankin', 'Sarnia', 'Walpole', 'Jocko Point'])('does not auto-fill a fleet card from quick-select on site "%s"', async (site) => {
     mockStore.stationName = site
     mockAxiosGet.mockImplementation((url: string) => {
       if (url.includes('quick-select')) {
@@ -408,7 +408,26 @@ describe('PO Form — index.tsx', () => {
     expect(mockStore.setCustomerName).toHaveBeenCalledWith('Batchewana Frist Nation of Ojibways')
   })
 
-  it.each(['Rankin', 'Sarnia', 'Walpole'])('does not pad poNumber to "00000" when clicking Upload Receipt on site "%s"', async (site) => {
+  it('shows a custom label on the quick-select button instead of the first word, when set', async () => {
+    mockAxiosGet.mockImplementation((url: string) => {
+      if (url.includes('quick-select')) {
+        return Promise.resolve({
+          data: [{ _id: 'qc1', name: 'Three fires development corporation', fleetCardNumber: '', label: 'Three Fires', order: 0 }],
+        })
+      }
+      return Promise.resolve({ data: [] })
+    })
+
+    renderWithSuspense(<POForm />)
+
+    const quickBtn = await waitFor(() => screen.getByRole('button', { name: 'Three Fires' }), { timeout: 5000 })
+    expect(screen.queryByText('Three', { selector: 'button' })).not.toBeInTheDocument()
+
+    fireEvent.click(quickBtn)
+    expect(mockStore.setCustomerName).toHaveBeenCalledWith('Three fires development corporation')
+  })
+
+  it.each(['Rankin', 'Sarnia', 'Walpole', 'Jocko Point'])('does not pad poNumber to "00000" when clicking Upload Receipt on site "%s"', async (site) => {
     mockStore.stationName = site
     mockStore.receipt = null
     renderWithSuspense(<POForm />)

--- a/frontend/src/routes/_navbarLayout/po/index.tsx
+++ b/frontend/src/routes/_navbarLayout/po/index.tsx
@@ -29,6 +29,7 @@ interface QuickSelectCustomer {
   _id: string
   name: string
   fleetCardNumber: string
+  label?: string
   order: number
 }
 
@@ -36,7 +37,7 @@ const PRODUCTS_CACHE_KEY = 'po_cachedProducts'
 
 // Sites with no PO Number / Fleet Card concept — the Number section is hidden
 // entirely and neither field is submitted with the purchase order.
-const NO_PO_NUMBER_SITES = ['Rankin', 'Sarnia', 'Walpole']
+const NO_PO_NUMBER_SITES = ['Rankin', 'Sarnia', 'Walpole', 'Jocko Point']
 
 async function loader() {
   try {
@@ -297,9 +298,12 @@ function RouteComponent() {
       active ? 'bg-slate-800 text-white' : 'bg-background text-slate-700 hover:bg-slate-50'
     }`
 
-  // Quick-select buttons show only the first word of the customer's full name
-  // (e.g. "Batchewana" for "Batchewana Frist Nation of Ojibways") to keep the row compact.
+  // Quick-select buttons default to showing only the first word of the customer's
+  // full name (e.g. "Batchewana" for "Batchewana Frist Nation of Ojibways") to keep
+  // the row compact — a custom `label` (set in Settings > Quick-Select Customers)
+  // overrides this when the first word alone doesn't read well.
   const firstWord = (name: string) => name.trim().split(' ')[0] || name
+  const quickSelectLabel = (qc: QuickSelectCustomer) => qc.label || firstWord(qc.name)
 
   return (
     <div className="p-4 border border-dashed border-gray-300 rounded-md space-y-6">
@@ -468,7 +472,7 @@ function RouteComponent() {
                   onClick={() => handleQuickCustomerTap(qc)}
                   className={toggleClass(selectedQuickCustomerId === qc._id, 'rounded-md border border-input')}
                 >
-                  {firstWord(qc.name)}
+                  {quickSelectLabel(qc)}
                 </button>
               ))}
             </div>

--- a/frontend/src/routes/_navbarLayout/settings/quick-customers/$site.tsx
+++ b/frontend/src/routes/_navbarLayout/settings/quick-customers/$site.tsx
@@ -12,6 +12,7 @@ interface QuickSelectEntry {
   _id: string
   name: string
   fleetCardNumber: string
+  label: string
   order: number
 }
 
@@ -65,11 +66,14 @@ function RouteComponent() {
 
   const [entries, setEntries] = useState<QuickSelectEntry[]>(initialEntries);
   const [fleetCardDrafts, setFleetCardDrafts] = useState<Record<string, string>>({});
+  const [labelDrafts, setLabelDrafts] = useState<Record<string, string>>({});
   const [savingId, setSavingId] = useState<string | null>(null);
+  const [savingLabelId, setSavingLabelId] = useState<string | null>(null);
 
   useEffect(() => {
     setEntries(initialEntries);
     setFleetCardDrafts(Object.fromEntries(initialEntries.map((e) => [e._id, e.fleetCardNumber || ''])));
+    setLabelDrafts(Object.fromEntries(initialEntries.map((e) => [e._id, e.label || ''])));
   }, [initialEntries]);
 
   const refresh = async () => {
@@ -156,6 +160,25 @@ function RouteComponent() {
     }
   };
 
+  const handleSaveLabel = async (entry: QuickSelectEntry) => {
+    const draft = (labelDrafts[entry._id] || '').trim();
+    setSavingLabelId(entry._id);
+    try {
+      await axios.put(`/api/ar-customers/${entry._id}/quick-select/label`, { stationName, label: draft }, {
+        headers: authHeaders(),
+      });
+      await refresh();
+    } catch (error: any) {
+      if (axios.isAxiosError(error) && error.response?.status === 403) {
+        navigate({ to: '/no-access' });
+        return;
+      }
+      alert(error?.response?.data?.error || 'Failed to save button label.');
+    } finally {
+      setSavingLabelId(null);
+    }
+  };
+
   const handleSaveFleetCard = async (entry: QuickSelectEntry) => {
     const draft = (fleetCardDrafts[entry._id] || '').trim();
     if (draft && !/^\d{16}$/.test(draft)) {
@@ -237,6 +260,23 @@ function RouteComponent() {
 
               <div className="flex-1">
                 <div className="font-medium">{entry.name}</div>
+                <div className="flex items-center gap-2 mt-1">
+                  <input
+                    type="text"
+                    value={labelDrafts[entry._id] ?? ''}
+                    onChange={(e) => setLabelDrafts((prev) => ({ ...prev, [entry._id]: e.target.value }))}
+                    placeholder={`Button text (default: "${entry.name.trim().split(' ')[0] || entry.name}")`}
+                    className="border border-gray-300 rounded-md p-1 text-sm w-64"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleSaveLabel(entry)}
+                    disabled={savingLabelId === entry._id}
+                    className="bg-blue-500 text-white px-2 py-1 rounded-md text-sm disabled:opacity-50"
+                  >
+                    {savingLabelId === entry._id ? 'Saving...' : 'Save'}
+                  </button>
+                </div>
               </div>
 
               <div className="flex items-center gap-2">


### PR DESCRIPTION
…r sites

Quick-select customer buttons on the PO form always showed just the first word of the customer's full legal name, which reads poorly for names like "Three fires development corporation". Adds an optional per-site label on ArCustomer.quickSelectSites (schema + API + a new label field on the Settings > Quick-Select Customers page) that overrides the first-word default when set.

Also extends the no-PO-number/fleet-card site list to include Jocko Point, alongside Rankin, Sarnia, and Walpole.