### PR TITLE
Cache the site list offline so pickers work without a network round-trip

### DIFF
--- a/frontend/src/components/custom/locationPicker.tsx
+++ b/frontend/src/components/custom/locationPicker.tsx
@@ -98,6 +98,7 @@ import {
 import axios from "axios";
 import { useAuth } from "@/context/AuthContext";
 import { useSite } from "@/context/SiteContext";
+import { getCachedLocations, saveCachedLocations } from "@/lib/locationsCache";
 
 interface Location {
   _id: string;
@@ -190,10 +191,19 @@ export function LocationPicker({
 }
 
 const fetchLocations = async () => {
-  const response = await axios.get("/api/locations", {
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
-    },
-  });
-  return response.data;
+  try {
+    const response = await axios.get("/api/locations", {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem("token")}`,
+      },
+    });
+    saveCachedLocations(response.data);
+    return response.data;
+  } catch {
+    // Offline (or request failed) — fall back to the last successful fetch,
+    // warmed as early as app boot (see prefetchLocations in main.tsx), so
+    // the picker isn't empty just because this particular page load couldn't
+    // reach the server.
+    return getCachedLocations();
+  }
 };

--- a/frontend/src/components/custom/sitePicker.tsx
+++ b/frontend/src/components/custom/sitePicker.tsx
@@ -11,6 +11,7 @@ import {
 import { useNavigate } from '@tanstack/react-router'
 import { useAuth } from "@/context/AuthContext"
 import { useSite } from "@/context/SiteContext"
+import { getCachedLocations, saveCachedLocations } from "@/lib/locationsCache"
 
 interface Location {
   _id: string
@@ -60,10 +61,21 @@ export function SitePicker({
         })
         if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`)
         const data = await response.json()
+        saveCachedLocations(data)
         setLocations(data)
       } catch (error) {
         console.error('Error fetching locations:', error)
-        setError('Failed to load locations')
+        // Offline (or request failed) — fall back to the last successful
+        // fetch instead of showing a permanent error, so the picker isn't
+        // empty just because this particular page load couldn't reach the
+        // server. Only surface the error message if there's truly nothing
+        // to fall back on.
+        const cached = getCachedLocations<Location>()
+        if (cached.length > 0) {
+          setLocations(cached)
+        } else {
+          setError('Failed to load locations')
+        }
       } finally {
         setLoading(false)
       }

--- a/frontend/src/lib/__tests__/locationsCache.test.ts
+++ b/frontend/src/lib/__tests__/locationsCache.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { saveCachedLocations, getCachedLocations, prefetchLocations } from '../locationsCache'
+
+const sampleLocations = [
+  { _id: '1', stationName: 'Rankin', csoCode: '001', timezone: 'America/Toronto' },
+  { _id: '2', stationName: 'Sarnia', csoCode: '002', timezone: 'America/Toronto' },
+]
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+// ─── saveCachedLocations / getCachedLocations ─────────────────────────────────
+
+describe('saveCachedLocations / getCachedLocations', () => {
+  it('round-trips a saved list', () => {
+    saveCachedLocations(sampleLocations)
+    expect(getCachedLocations()).toEqual(sampleLocations)
+  })
+
+  it('returns an empty array when nothing has ever been cached', () => {
+    expect(getCachedLocations()).toEqual([])
+  })
+
+  it('returns an empty array for corrupted JSON instead of throwing', () => {
+    localStorage.setItem('cachedLocations', '{not valid json')
+    expect(getCachedLocations()).toEqual([])
+  })
+
+  it('returns an empty array if the cached value is not an array', () => {
+    localStorage.setItem('cachedLocations', JSON.stringify({ not: 'an array' }))
+    expect(getCachedLocations()).toEqual([])
+  })
+
+  it('overwrites the previous cache on each save', () => {
+    saveCachedLocations([sampleLocations[0]])
+    saveCachedLocations(sampleLocations)
+    expect(getCachedLocations()).toEqual(sampleLocations)
+  })
+})
+
+// ─── prefetchLocations ─────────────────────────────────────────────────────────
+
+describe('prefetchLocations', () => {
+  it('caches the response body on a successful fetch', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(sampleLocations),
+    }))
+
+    prefetchLocations()
+    // fetch + .then chain resolve on microtasks — flush them
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(getCachedLocations()).toEqual(sampleLocations)
+  })
+
+  it('leaves any existing cache untouched when the fetch fails (offline)', async () => {
+    saveCachedLocations(sampleLocations)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network Error')))
+
+    prefetchLocations()
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(getCachedLocations()).toEqual(sampleLocations)
+  })
+
+  it('does not throw when the response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
+
+    expect(() => prefetchLocations()).not.toThrow()
+    await new Promise((r) => setTimeout(r, 0))
+  })
+})

--- a/frontend/src/lib/locationsCache.ts
+++ b/frontend/src/lib/locationsCache.ts
@@ -1,0 +1,38 @@
+// Shared offline cache for the site/location list. GET /api/locations
+// requires no auth (see backend/routes/location.js), so this is prefetched
+// eagerly on app boot — even on the login page — rather than waiting for an
+// authenticated route to request it. Every site picker reads and writes the
+// same key, so the moment any of them succeeds online, the whole app has an
+// offline fallback for the next time any of them is rendered.
+const CACHE_KEY = 'cachedLocations'
+
+export function saveCachedLocations(locations: unknown[]): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(locations))
+  } catch {
+    // localStorage full/unavailable — non-fatal, just skip caching
+  }
+}
+
+export function getCachedLocations<T = any>(): T[] {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY)
+    const parsed = raw ? JSON.parse(raw) : []
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+// Fire-and-forget: warms the cache as early as possible on every app load,
+// regardless of auth state. A failure here (offline, or a first-ever load
+// with nothing cached yet) is expected and silently ignored — readers just
+// fall back to whatever was cached last time, or an empty list.
+export function prefetchLocations(): void {
+  fetch('/api/locations', {
+    headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+  })
+    .then((res) => (res.ok ? res.json() : Promise.reject(res)))
+    .then((data) => saveCachedLocations(data))
+    .catch(() => {})
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,11 @@ import ReactDOM from 'react-dom/client'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
 import { AuthProvider } from '@/context/AuthContext'
 import { SiteProvider } from '@/context/SiteContext'
+import { prefetchLocations } from '@/lib/locationsCache'
+
+// Warms the offline site-list cache as soon as the app boots — before login,
+// before routing — since GET /api/locations doesn't require auth.
+prefetchLocations()
 
 // Import the generated route tree
 import { routeTree } from './routeTree.gen'


### PR DESCRIPTION
LocationPicker and SitePicker fetched /api/locations with no persistence and no fallback, so any page load without connectivity showed "No stations available" — even though this endpoint requires no auth and could have been warmed long before.

Adds a shared localStorage cache (lib/locationsCache.ts) that both pickers read on failure and write on every successful fetch, and prefetches it once at app boot in main.tsx — before routing, before login — so the site list is available offline from the first successful load onward, on any page including the login screen.