### PR TITLE
Prefetch AR customer list on login, mirroring the locations cache

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -11,6 +11,7 @@ import { createContext, useContext, useState, useEffect, useRef } from "react";
 import { jwtDecode } from "jwt-decode";
 // import { getSocket } from "@/lib/websocket";
 import axios from "axios";
+import { prefetchArCustomers } from "@/lib/arCustomersCache";
 // import { domain } from '@/lib/constants'
 
 /* -----------------------------------------------------
@@ -158,6 +159,15 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
 
   }, []);
+
+  // Warms the AR-customer offline cache as soon as we have a valid user —
+  // covers both a fresh login and an app boot that finds an already-valid
+  // token (the common case, since a token persists across sessions). GET
+  // /api/ar-customers requires auth, so this can't run any earlier than
+  // this, unlike the unauthenticated locations prefetch in main.tsx.
+  useEffect(() => {
+    if (user) prefetchArCustomers();
+  }, [user]);
 
   return (
     <AuthContext.Provider value={{ user, setUser, refreshAuth, refreshTokenFromBackend }}>

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+
+const { mockPrefetchArCustomers, mockJwtDecode } = vi.hoisted(() => ({
+  mockPrefetchArCustomers: vi.fn(),
+  mockJwtDecode: vi.fn(),
+}))
+
+vi.mock('@/lib/arCustomersCache', () => ({
+  prefetchArCustomers: mockPrefetchArCustomers,
+}))
+
+vi.mock('jwt-decode', () => ({
+  jwtDecode: mockJwtDecode,
+}))
+
+import { AuthProvider, useAuth } from '../AuthContext'
+
+function Consumer() {
+  const { user } = useAuth()
+  return <div data-testid="user">{user ? user.email : 'no-user'}</div>
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('AuthProvider — AR customer prefetch on login', () => {
+  it('prefetches AR customers once a valid token resolves to a user (fresh login / returning session)', async () => {
+    localStorage.setItem('token', 'a-token')
+    mockJwtDecode.mockReturnValue({ id: 'u1', email: 'user@example.com', permissions: [], site_access: {} })
+
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(mockPrefetchArCustomers).toHaveBeenCalled())
+  })
+
+  it('does not prefetch AR customers when there is no token (logged out / login page)', async () => {
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(mockJwtDecode).not.toHaveBeenCalled())
+    expect(mockPrefetchArCustomers).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/__tests__/arCustomersCache.test.ts
+++ b/frontend/src/lib/__tests__/arCustomersCache.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { saveCachedArCustomers, getCachedArCustomers, prefetchArCustomers } from '../arCustomersCache'
+
+const sampleCustomers = [
+  { _id: '1', name: 'Acme Trucking' },
+  { _id: '2', name: 'Three fires development corporation' },
+]
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+// ─── saveCachedArCustomers / getCachedArCustomers ─────────────────────────────
+
+describe('saveCachedArCustomers / getCachedArCustomers', () => {
+  it('round-trips a saved list', () => {
+    saveCachedArCustomers(sampleCustomers)
+    expect(getCachedArCustomers()).toEqual(sampleCustomers)
+  })
+
+  it('returns an empty array when nothing has ever been cached', () => {
+    expect(getCachedArCustomers()).toEqual([])
+  })
+
+  it('returns an empty array for corrupted JSON instead of throwing', () => {
+    localStorage.setItem('po_cachedArCustomers', '{not valid json')
+    expect(getCachedArCustomers()).toEqual([])
+  })
+
+  it('returns an empty array if the cached value is not an array', () => {
+    localStorage.setItem('po_cachedArCustomers', JSON.stringify({ not: 'an array' }))
+    expect(getCachedArCustomers()).toEqual([])
+  })
+})
+
+// ─── prefetchArCustomers ────────────────────────────────────────────────────────
+
+describe('prefetchArCustomers', () => {
+  it('does nothing when there is no auth token yet (pre-login)', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+
+    prefetchArCustomers()
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(getCachedArCustomers()).toEqual([])
+  })
+
+  it('caches the response body on a successful fetch once logged in', async () => {
+    localStorage.setItem('token', 'test-token')
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(sampleCustomers),
+    }))
+
+    prefetchArCustomers()
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(getCachedArCustomers()).toEqual(sampleCustomers)
+  })
+
+  it('leaves any existing cache untouched when the fetch fails (offline)', async () => {
+    localStorage.setItem('token', 'test-token')
+    saveCachedArCustomers(sampleCustomers)
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network Error')))
+
+    prefetchArCustomers()
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(getCachedArCustomers()).toEqual(sampleCustomers)
+  })
+})

--- a/frontend/src/lib/arCustomersCache.ts
+++ b/frontend/src/lib/arCustomersCache.ts
@@ -1,0 +1,43 @@
+// Shared offline cache for the full AR customer list (used for the
+// customer-name autocomplete on the PO form, among others). Unlike
+// locations, GET /api/ar-customers requires auth, so it can't be prefetched
+// pre-login like locationsCache.ts — instead it's prefetched as soon as
+// AuthContext resolves a valid user (fresh login, or an app boot that finds
+// an already-valid token — see the effect in context/AuthContext.tsx), and
+// re-cached on every subsequent successful fetch from wherever the list is
+// consumed (e.g. po/index.tsx).
+const CACHE_KEY = 'po_cachedArCustomers'
+
+export function saveCachedArCustomers(customers: unknown[]): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(customers))
+  } catch {
+    // localStorage full/unavailable — non-fatal, just skip caching
+  }
+}
+
+export function getCachedArCustomers<T = any>(): T[] {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY)
+    const parsed = raw ? JSON.parse(raw) : []
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+// Fire-and-forget: warms the cache as soon as a valid auth token exists. A
+// failure here (offline, or a first-ever load with nothing cached yet) is
+// expected and silently ignored — readers just fall back to whatever was
+// cached last time, or an empty list.
+export function prefetchArCustomers(): void {
+  const token = localStorage.getItem('token')
+  if (!token) return // not logged in yet — nothing to authenticate the request with
+
+  fetch('/api/ar-customers', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+    .then((res) => (res.ok ? res.json() : Promise.reject(res)))
+    .then((data) => saveCachedArCustomers(data))
+    .catch(() => {})
+}

--- a/frontend/src/routes/_navbarLayout/__tests__/po.test.tsx
+++ b/frontend/src/routes/_navbarLayout/__tests__/po.test.tsx
@@ -408,6 +408,64 @@ describe('PO Form — index.tsx', () => {
     expect(mockStore.setCustomerName).toHaveBeenCalledWith('Batchewana Frist Nation of Ojibways')
   })
 
+  it('falls back to the cached AR customer list when the fetch fails (offline)', async () => {
+    localStorage.setItem('po_cachedArCustomers', JSON.stringify([{ _id: 'c1', name: 'Jane Doe Trucking' }]))
+    mockAxiosGet.mockImplementation((url: string) => {
+      if (url.includes('ar-customers/quick-select')) return Promise.resolve({ data: [] })
+      if (url.includes('ar-customers')) {
+        return Promise.reject(Object.assign(new Error('Network Error'), { isAxiosErr: true }))
+      }
+      return Promise.resolve({ data: [] })
+    })
+
+    renderWithSuspense(<POForm />)
+
+    const nameInput = await waitFor(() => screen.getByDisplayValue('Jane Doe'), { timeout: 5000 })
+    fireEvent.focus(nameInput)
+
+    await waitFor(() => expect(screen.getByText('Jane Doe Trucking')).toBeInTheDocument())
+
+    localStorage.removeItem('po_cachedArCustomers')
+  })
+
+  it('caches the AR customer list to localStorage on a successful fetch', async () => {
+    localStorage.removeItem('po_cachedArCustomers')
+    const fetchedCustomers = [{ _id: 'c2', name: 'Acme Co' }]
+    mockAxiosGet.mockImplementation((url: string) => {
+      if (url.includes('ar-customers/quick-select')) return Promise.resolve({ data: [] })
+      if (url.includes('ar-customers')) return Promise.resolve({ data: fetchedCustomers })
+      return Promise.resolve({ data: [] })
+    })
+
+    renderWithSuspense(<POForm />)
+
+    await waitFor(() => {
+      const cached = localStorage.getItem('po_cachedArCustomers')
+      expect(cached ? JSON.parse(cached) : null).toEqual(fetchedCustomers)
+    }, { timeout: 5000 })
+  })
+
+  it('falls back to the cached quick-select list for a station when the fetch fails (offline)', async () => {
+    // mockStore.stationName defaults to 'TestSite' (see resetStore)
+    localStorage.setItem('po_cachedQuickSelect_TestSite', JSON.stringify([
+      { _id: 'qc1', name: 'Cached Customer', fleetCardNumber: '', order: 0 },
+    ]))
+    mockAxiosGet.mockImplementation((url: string) => {
+      if (url.includes('ar-customers/quick-select')) {
+        return Promise.reject(Object.assign(new Error('Network Error'), { isAxiosErr: true }))
+      }
+      return Promise.resolve({ data: [] })
+    })
+
+    renderWithSuspense(<POForm />)
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Cached' })).toBeInTheDocument()
+    , { timeout: 5000 })
+
+    localStorage.removeItem('po_cachedQuickSelect_TestSite')
+  })
+
   it('shows a custom label on the quick-select button instead of the first word, when set', async () => {
     mockAxiosGet.mockImplementation((url: string) => {
       if (url.includes('quick-select')) {

--- a/frontend/src/routes/_navbarLayout/po/index.tsx
+++ b/frontend/src/routes/_navbarLayout/po/index.tsx
@@ -13,6 +13,7 @@ import { DatePicker } from '@/components/custom/datePicker';
 import { LocationPicker } from '@/components/custom/locationPicker';
 import { domain } from '@/lib/constants'
 import { Camera, ExternalLink } from 'lucide-react'
+import { getCachedArCustomers, saveCachedArCustomers } from '@/lib/arCustomersCache'
 
 interface Product {
   _id: string
@@ -34,6 +35,7 @@ interface QuickSelectCustomer {
 }
 
 const PRODUCTS_CACHE_KEY = 'po_cachedProducts'
+const QUICK_SELECT_CACHE_PREFIX = 'po_cachedQuickSelect_'
 
 // Sites with no PO Number / Fleet Card concept — the Number section is hidden
 // entirely and neither field is submitted with the purchase order.
@@ -121,7 +123,11 @@ function RouteComponent() {
 
   const [poError, setPoError] = useState<string>('')
   const [cardStatus, setCardStatus] = useState<string | null>(null)
-  const [arCustomers, setArCustomers] = useState<ArCustomer[]>([])
+  // Seeded from the offline cache so the autocomplete has data immediately on
+  // render (it's likely already warm — see the eager prefetch in
+  // AuthContext.tsx, fired as soon as login resolves) instead of waiting for
+  // this page's own fetch below to succeed or fail first.
+  const [arCustomers, setArCustomers] = useState<ArCustomer[]>(() => getCachedArCustomers<ArCustomer>())
   const [showSuggestions, setShowSuggestions] = useState(false)
   const customerNameRef = useRef<HTMLDivElement>(null)
   const [quickSelectCustomers, setQuickSelectCustomers] = useState<QuickSelectCustomer[]>([])
@@ -177,19 +183,38 @@ function RouteComponent() {
         headers: { Authorization: `Bearer ${token}` },
       })
     ).then((res) => {
-      if (Array.isArray(res?.data)) setArCustomers(res.data)
-    }).catch(() => {})
+      if (Array.isArray(res?.data)) {
+        setArCustomers(res.data)
+        saveCachedArCustomers(res.data)
+      }
+    }).catch(() => {
+      // Offline (or request failed) — the arCustomers state is already
+      // seeded from the same cache above, so there's nothing more to do here.
+    })
   }, [])
 
   useEffect(() => {
     if (!stationName) { setQuickSelectCustomers([]); return }
     const token = localStorage.getItem('token')
+    const cacheKey = `${QUICK_SELECT_CACHE_PREFIX}${stationName}`
     axios.get(`${domain}/api/ar-customers/quick-select`, {
       params: { stationName },
       headers: { Authorization: `Bearer ${token}` },
     }).then((res) => {
-      if (Array.isArray(res?.data)) setQuickSelectCustomers(res.data)
-    }).catch(() => setQuickSelectCustomers([]))
+      if (Array.isArray(res?.data)) {
+        setQuickSelectCustomers(res.data)
+        localStorage.setItem(cacheKey, JSON.stringify(res.data))
+      }
+    }).catch(() => {
+      // Offline (or request failed) — fall back to this station's last
+      // successful fetch instead of clearing the quick-select buttons.
+      try {
+        const cached = localStorage.getItem(cacheKey)
+        setQuickSelectCustomers(cached ? JSON.parse(cached) : [])
+      } catch {
+        setQuickSelectCustomers([])
+      }
+    })
   }, [stationName])
 
   useEffect(() => {


### PR DESCRIPTION
The customer-name autocomplete on the PO form only fetched AR customers when that page mounted, with no offline persistence — a fresh/cold load without connectivity had nothing to show.

Adds lib/arCustomersCache.ts (same save/get/prefetch shape as the existing locationsCache.ts) and prefetches it in AuthContext as soon as a valid user resolves — covering both a fresh login and an app boot that finds an already-valid token, which is the common case since tokens persist across sessions. GET /api/ar-customers requires auth, so unlike locations this can't be warmed before login.

po/index.tsx now seeds its arCustomers state directly from that same cache on mount (instead of starting empty and waiting on its own fetch to fail first) and reuses the shared save/read helpers instead of duplicating the caching logic inline.