### PR TITLE
Fix LocationPicker getting permanently stuck empty offline

### DIFF
--- a/frontend/src/components/custom/__tests__/locationPicker.test.tsx
+++ b/frontend/src/components/custom/__tests__/locationPicker.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const { mockAxiosGet } = vi.hoisted(() => ({ mockAxiosGet: vi.fn() }))
+
+vi.mock('axios', () => ({
+  default: { get: mockAxiosGet },
+}))
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: { location: 'Rankin', access: { site_access: { Rankin: true } } } }),
+}))
+
+vi.mock('@/context/SiteContext', () => ({
+  useSite: () => ({ selectedSite: '', setSelectedSite: vi.fn() }),
+}))
+
+import { LocationPicker } from '../locationPicker'
+
+const renderPicker = (queryClient: QueryClient) =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <LocationPicker setStationName={vi.fn()} value="stationName" />
+    </QueryClientProvider>
+  )
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+// Regression coverage: fetchLocations used to catch a failed request and
+// always return getCachedLocations() — including an empty array when
+// nothing had ever been cached. React Query then treated that empty array
+// as a genuine success and froze it as "fresh" for the app's global 5-minute
+// staleTime, silently blocking every retry mechanism (remount, reconnect,
+// window refocus) until that window expired. This is exactly why a fresh
+// offline load could get permanently stuck on "No stations available" even
+// after connectivity returned, while `arCustomers` (plain useEffect, no
+// staleTime) kept working — see the fix in locationPicker.tsx.
+describe('LocationPicker — offline query caching', () => {
+  it('surfaces a real error (not a frozen empty success) when the fetch fails and nothing is cached yet', async () => {
+    mockAxiosGet.mockRejectedValue(new Error('Network Error'))
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    renderPicker(queryClient)
+
+    await waitFor(() => {
+      const state = queryClient.getQueryState(['locations'])
+      expect(state?.status).toBe('error')
+    })
+  })
+
+  it('succeeds with the cached list when the fetch fails but a previous fetch had populated the cache', async () => {
+    const cached = [{ _id: '1', stationName: 'Rankin', csoCode: '001', timezone: 'America/Toronto' }]
+    localStorage.setItem('cachedLocations', JSON.stringify(cached))
+    mockAxiosGet.mockRejectedValue(new Error('Network Error'))
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    renderPicker(queryClient)
+
+    await waitFor(() => {
+      const state = queryClient.getQueryState(['locations'])
+      expect(state?.status).toBe('success')
+      expect(state?.data).toEqual(cached)
+    })
+  })
+
+  it('succeeds and caches the response on a normal successful fetch', async () => {
+    const fetched = [{ _id: '2', stationName: 'Sarnia', csoCode: '002', timezone: 'America/Toronto' }]
+    mockAxiosGet.mockResolvedValue({ data: fetched })
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    renderPicker(queryClient)
+
+    await waitFor(() => {
+      const state = queryClient.getQueryState(['locations'])
+      expect(state?.status).toBe('success')
+    })
+    expect(JSON.parse(localStorage.getItem('cachedLocations') || 'null')).toEqual(fetched)
+  })
+})

--- a/frontend/src/components/custom/locationPicker.tsx
+++ b/frontend/src/components/custom/locationPicker.tsx
@@ -199,11 +199,19 @@ const fetchLocations = async () => {
     });
     saveCachedLocations(response.data);
     return response.data;
-  } catch {
+  } catch (err) {
     // Offline (or request failed) — fall back to the last successful fetch,
     // warmed as early as app boot (see prefetchLocations in main.tsx), so
     // the picker isn't empty just because this particular page load couldn't
-    // reach the server.
-    return getCachedLocations();
+    // reach the server. Only treat this as a "successful" result when the
+    // cache actually has something in it — React Query marks whatever this
+    // function returns as fresh data for the global 5-minute staleTime, so
+    // returning an empty array here would look identical to a real success
+    // and block any retry (remount, reconnect, window refocus) until that
+    // window expires. Re-throwing on a genuinely empty cache instead lets
+    // React Query's normal retry/refetchOnReconnect behavior keep trying.
+    const cached = getCachedLocations();
+    if (cached.length > 0) return cached;
+    throw err;
   }
 };


### PR DESCRIPTION
fetchLocations caught every failed request and returned the cached locations array unconditionally, including when that cache was empty (e.g. a genuinely fresh offline load with nothing cached yet). React Query has no way to tell that apart from a real success, so it froze the empty result as fresh for the app's global 5-minute staleTime — silently blocking every retry mechanism (remount, reconnect, window refocus) until that window expired. AR customers never hit this since that fetch bypasses React Query entirely.

Now only returns the cache as a success when it actually has data; otherwise it re-throws so the query lands in a real error state and React Query's default retry/refetchOnReconnect behavior can recover once connectivity returns.