### PR TITLE
Fix site picker stuck offline on a real device (hung fetch, not just …

### DIFF
--- a/frontend/src/components/custom/__tests__/locationPicker.test.tsx
+++ b/frontend/src/components/custom/__tests__/locationPicker.test.tsx
@@ -80,4 +80,29 @@ describe('LocationPicker — offline query caching', () => {
     })
     expect(JSON.parse(localStorage.getItem('cachedLocations') || 'null')).toEqual(fetched)
   })
+
+  // Regression coverage: even with the error-vs-success fix above, the query
+  // still started as `undefined`/isPending until fetchLocations() settled —
+  // fine for a fetch that fails fast, but a fetch to a host that's reachable
+  // at the network layer but not actually online (dead router, captive
+  // portal) can hang far longer than a user will wait, with nothing to show
+  // in the meantime despite a warm cache sitting right there. `initialData`
+  // means the query has cached data synchronously on the very first render,
+  // independent of whether/when the live fetch ever settles.
+  it('has the cached data available immediately, synchronously on first render, even while the live fetch is still hung', () => {
+    const cached = [{ _id: '3', stationName: 'Walpole', csoCode: '003', timezone: 'America/Toronto' }]
+    localStorage.setItem('cachedLocations', JSON.stringify(cached))
+    mockAxiosGet.mockReturnValue(new Promise(() => {})) // never resolves — simulates a hung request
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    renderPicker(queryClient)
+
+    // No waitFor — this must be true immediately, before any microtask runs.
+    const state = queryClient.getQueryState(['locations'])
+    expect(state?.status).toBe('success')
+    expect(state?.data).toEqual(cached)
+    // Still marked stale (not trusted for the full 5-minute staleTime), so a
+    // real background refetch attempt still happens.
+    expect(state?.dataUpdatedAt).toBe(0)
+  })
 })

--- a/frontend/src/components/custom/__tests__/sitePicker.test.tsx
+++ b/frontend/src/components/custom/__tests__/sitePicker.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: { location: 'Rankin', access: { site_access: { Rankin: true } } } }),
+}))
+
+vi.mock('@/context/SiteContext', () => ({
+  useSite: () => ({ selectedSite: '', setSelectedSite: vi.fn() }),
+}))
+
+import { SitePicker } from '../sitePicker'
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+// Regression coverage: SitePicker used to start with empty locations and
+// loading=true unconditionally, only consulting the offline cache inside the
+// fetch's catch block. A fetch to a host that's reachable but not actually
+// online (dead router, captive portal — realistic on a tablet's Wi-Fi, unlike
+// a clean disconnect) could hang indefinitely without ever reaching that
+// catch block, leaving the picker stuck on "Loading locations..." forever
+// even with a warm cache sitting right there in localStorage. Seeding initial
+// state from the cache means the picker never depends on the live fetch
+// settling at all — the "Loading locations..." placeholder (rendered
+// unconditionally in the closed trigger, unlike the actual option list which
+// is Radix-portal-mounted and only present once opened) is the reliable
+// signal that this seeding worked.
+describe('SitePicker — offline cache seeding', () => {
+  it('does not show the loading placeholder when a cache already exists, even if the live fetch never resolves', () => {
+    localStorage.setItem('cachedLocations', JSON.stringify([{ _id: '1', stationName: 'Rankin' }]))
+    // A fetch that never resolves — simulates a hung request (dead
+    // router/captive portal) rather than one that fails fast.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+
+    render(<SitePicker />)
+
+    expect(screen.queryByText('Loading locations...')).not.toBeInTheDocument()
+  })
+
+  it('shows the loading placeholder when there is no cache yet and the fetch is still pending', () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+
+    render(<SitePicker />)
+
+    expect(screen.getByText('Loading locations...')).toBeInTheDocument()
+  })
+
+  it('updates the cache and clears the loading placeholder once the live fetch succeeds', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ _id: '2', stationName: 'Sarnia' }]),
+    }))
+
+    render(<SitePicker />)
+    expect(screen.getByText('Loading locations...')).toBeInTheDocument()
+
+    await waitFor(() => expect(screen.queryByText('Loading locations...')).not.toBeInTheDocument())
+    expect(JSON.parse(localStorage.getItem('cachedLocations') || 'null')).toEqual([{ _id: '2', stationName: 'Sarnia' }])
+  })
+
+  it('bounds the fetch with an abort signal, so a hung connection eventually gives up', () => {
+    const fetchSpy = vi.fn(() => new Promise(() => {}))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    render(<SitePicker />)
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/locations', expect.objectContaining({
+      signal: expect.any(AbortSignal),
+    }))
+  })
+})

--- a/frontend/src/components/custom/locationPicker.tsx
+++ b/frontend/src/components/custom/locationPicker.tsx
@@ -123,6 +123,20 @@ export function LocationPicker({
   const { data: locations } = useQuery({
     queryKey: ["locations"],
     queryFn: fetchLocations,
+    // Seeds the query with whatever was cached from a previous successful
+    // fetch (see prefetchLocations() in main.tsx/__root.tsx) so the picker
+    // has data on the very first render, regardless of whether this
+    // component's own fetchLocations() call has settled — a fetch to a
+    // reachable-but-not-actually-online host (dead router, captive portal)
+    // can hang far longer than a user will wait for "isPending" to resolve.
+    // initialDataUpdatedAt: 0 marks this as already stale so a real refetch
+    // still fires in the background rather than trusting it for the full
+    // 5-minute staleTime.
+    initialData: () => {
+      const cached = getCachedLocations<Location>();
+      return cached.length > 0 ? cached : undefined;
+    },
+    initialDataUpdatedAt: 0,
   });
 
   const { user } = useAuth();
@@ -196,6 +210,10 @@ const fetchLocations = async () => {
       headers: {
         Authorization: `Bearer ${localStorage.getItem("token")}`,
       },
+      // Bounds how long a reachable-but-not-actually-online connection (dead
+      // Wi-Fi router, captive portal) can hang this request before we give up
+      // and fall back to the cache below.
+      timeout: 5000,
     });
     saveCachedLocations(response.data);
     return response.data;

--- a/frontend/src/components/custom/sitePicker.tsx
+++ b/frontend/src/components/custom/sitePicker.tsx
@@ -33,8 +33,14 @@ export function SitePicker({
   label = "Sites",
   className = "w-[180px]"
 }: SitePickerProps) {
-  const [locations, setLocations] = useState<Location[]>([])
-  const [loading, setLoading] = useState(true)
+  // Seeded from the offline cache so the picker shows data immediately on
+  // render instead of depending on the live fetch below ever settling — a
+  // fetch to a host that's reachable at the network layer but not actually
+  // online (dead router, captive portal — common on a tablet's Wi-Fi, unlike
+  // a clean "no connection" disconnect) can hang far longer than a user will
+  // wait, and previously nothing was shown until that fetch's catch block ran.
+  const [locations, setLocations] = useState<Location[]>(() => getCachedLocations<Location>())
+  const [loading, setLoading] = useState(() => getCachedLocations<Location>().length === 0)
   const [error, setError] = useState<string | null>(null)
   const { user } = useAuth()
   const { selectedSite, setSelectedSite } = useSite()
@@ -52,12 +58,17 @@ export function SitePicker({
   useEffect(() => {
     const fetchLocations = async () => {
       try {
-        setLoading(true)
         setError(null)
         const response = await fetch('/api/locations', {
           headers: {
             Authorization: `Bearer ${localStorage.getItem('token')}`
-          }
+          },
+          // Bounds how long a reachable-but-not-actually-online connection
+          // (dead Wi-Fi router, captive portal) can hang this request —
+          // without this, a hung fetch would never reach the catch block
+          // below at all. See network.ts's isActuallyOnline() for the same
+          // pattern already established elsewhere in this codebase.
+          signal: AbortSignal.timeout(5000),
         })
         if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`)
         const data = await response.json()
@@ -69,7 +80,9 @@ export function SitePicker({
         // fetch instead of showing a permanent error, so the picker isn't
         // empty just because this particular page load couldn't reach the
         // server. Only surface the error message if there's truly nothing
-        // to fall back on.
+        // to fall back on. (locations/loading already start seeded from this
+        // same cache — this branch mainly matters for a stale-but-nonempty
+        // cache growing stale further, or a genuinely first-ever load.)
         const cached = getCachedLocations<Location>()
         if (cached.length > 0) {
           setLocations(cached)

--- a/frontend/src/lib/__tests__/locationsCache.test.ts
+++ b/frontend/src/lib/__tests__/locationsCache.test.ts
@@ -72,4 +72,20 @@ describe('prefetchLocations', () => {
     expect(() => prefetchLocations()).not.toThrow()
     await new Promise((r) => setTimeout(r, 0))
   })
+
+  // Regression coverage: without a bounded signal, a fetch to a host that's
+  // reachable at the network layer but not actually online (dead router,
+  // captive portal) can hang indefinitely instead of failing, so this
+  // fire-and-forget prefetch would never get around to warming the cache at
+  // all for that session.
+  it('bounds the request with an abort signal, so a hung connection cannot block this indefinitely', () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    prefetchLocations()
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/locations', expect.objectContaining({
+      signal: expect.any(AbortSignal),
+    }))
+  })
 })

--- a/frontend/src/lib/locationsCache.ts
+++ b/frontend/src/lib/locationsCache.ts
@@ -27,10 +27,16 @@ export function getCachedLocations<T = any>(): T[] {
 // Fire-and-forget: warms the cache as early as possible on every app load,
 // regardless of auth state. A failure here (offline, or a first-ever load
 // with nothing cached yet) is expected and silently ignored — readers just
-// fall back to whatever was cached last time, or an empty list.
+// fall back to whatever was cached last time, or an empty list. The 5s
+// timeout matters even though this is fire-and-forget: without it, a
+// reachable-but-not-actually-online connection (dead router, captive
+// portal) can leave this fetch hanging indefinitely instead of failing,
+// so it never gets around to warming the cache at all — see network.ts's
+// isActuallyOnline() for the same pattern already used elsewhere here.
 export function prefetchLocations(): void {
   fetch('/api/locations', {
     headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+    signal: AbortSignal.timeout(5000),
   })
     .then((res) => (res.ok ? res.json() : Promise.reject(res)))
     .then((data) => saveCachedLocations(data))


### PR DESCRIPTION
…failed fetch)

Playwright's setOffline() verified locations caching worked, but it fails every request instantly — it can't reproduce a connection that's reachable but not actually online (dead router, captive portal), which is the more realistic condition on a tablet's Wi-Fi. None of prefetchLocations(), SitePicker's fetch, or LocationPicker's axios.get had a timeout, and neither picker seeded its initial UI state from the cache — both started empty/loading and only consulted the cache inside a catch block that a hung (never-settling) request would never reach. AR customers worked throughout because po/index.tsx seeds its state synchronously from cache, making a hung fetch there invisible to the user; these two pickers didn't have that property.

Fix, applied to all three call sites: seed initial state from the cache (useState lazy initializer for SitePicker, React Query initialData for LocationPicker) so a hung fetch can never block cached data from showing, and bound each fetch with a 5s timeout (AbortSignal.timeout / axios timeout), matching the pattern network.ts's isActuallyOnline() already established in this codebase.

Verified against a real hung connection with Playwright route interception (accept the request, never respond) rather than setOffline(): page render is unaffected, and the hung requests are genuinely aborted client-side via net::ERR_ABORTED after 5s.