### PR TITLE
Always queue PO submissions locally, fixing the stuck "Saving..." button

### DIFF
--- a/frontend/src/components/custom/navbar.tsx
+++ b/frontend/src/components/custom/navbar.tsx
@@ -4,8 +4,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { isTokenExpired } from '../../lib/utils'
 import axios from 'axios'
 import { getSocket } from "@/lib/websocket";
-import { syncPendingActions } from "@/lib/utils"
-import { isActuallyOnline } from "@/lib/network";
+import { triggerBackgroundSync } from "@/lib/utils"
 import { useAuth } from "@/context/AuthContext";
 import { HelpCircle, LogOut, Settings as SettingsIcon, LayoutDashboard, Home as HomeIcon, KeyRound, ExternalLink, Bell } from 'lucide-react'
 import { clearLocalDB } from "@/lib/orderRecIndexedDB";
@@ -81,31 +80,22 @@ export default function Navbar() {
 
 
 
-  // checking for api health and syncing db once in online mode every 1 mins
+  // Global background sync trigger — this navbar is rendered on every
+  // authenticated page (_navbarLayout.tsx), so this is what makes the
+  // offline queue (purchase orders, order rec edits, ...) sync regardless of
+  // which module the user is currently in, not just while on that module's
+  // own page. triggerBackgroundSync() checks connectivity itself and is a
+  // no-op if genuinely offline.
   useEffect(() => {
-    // 1️⃣ Sync when back online
-    const handleOnline = async () => {
-      const online = await isActuallyOnline();
-      if (online) {
-        console.log("🌐 Online — attempting background sync...");
-        syncPendingActions();
-      } else {
-        console.warn("⚠️ Still offline — skipping sync");
-      }
+    const handleOnline = () => {
+      console.log("🌐 Online — attempting background sync...");
+      triggerBackgroundSync();
     };
 
     window.addEventListener("online", handleOnline);
 
-    // Also sync every 1 minute if actually online
-    const interval = setInterval(async () => {
-      const online = await isActuallyOnline();
-      console.log("checking for backend connectivity:", online)
-      if (online) {
-        console.log("Running updates")
-        syncPendingActions();
-      } else {
-        console.warn("⚠️ Offline during periodic check — skipping sync");
-      }
+    const interval = setInterval(() => {
+      triggerBackgroundSync();
     }, 15 * 1000); // 15 sec
 
     return () => {

--- a/frontend/src/lib/__tests__/syncPendingActions.test.ts
+++ b/frontend/src/lib/__tests__/syncPendingActions.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const {
+  mockAxiosPost,
+  mockGetPendingActionEntries,
+  mockDeletePendingAction,
+  mockUpdatePendingAction,
+  mockSaveOrderRec,
+  mockIsActuallyOnline,
+} = vi.hoisted(() => ({
+  mockAxiosPost: vi.fn(),
+  mockGetPendingActionEntries: vi.fn(),
+  mockDeletePendingAction: vi.fn().mockResolvedValue(undefined),
+  mockUpdatePendingAction: vi.fn().mockResolvedValue(undefined),
+  mockSaveOrderRec: vi.fn().mockResolvedValue(undefined),
+  mockIsActuallyOnline: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: mockAxiosPost,
+    put: vi.fn(),
+    patch: vi.fn(),
+    isAxiosError: (err: any) => !!(err && err.isAxiosErr),
+  },
+  isAxiosError: (err: any) => !!(err && err.isAxiosErr),
+}))
+
+vi.mock('@/lib/orderRecIndexedDB', () => ({
+  getPendingActionEntries: mockGetPendingActionEntries,
+  deletePendingAction: mockDeletePendingAction,
+  updatePendingAction: mockUpdatePendingAction,
+  saveOrderRec: mockSaveOrderRec,
+}))
+
+vi.mock('@/lib/network', () => ({
+  isActuallyOnline: mockIsActuallyOnline,
+}))
+
+import { syncPendingActions, triggerBackgroundSync } from '../utils'
+
+const poAction = (overrides: Record<string, any> = {}) => ({
+  type: 'CREATE_PURCHASE_ORDER',
+  receipt: 'data:image/png;base64,abc',
+  payload: { source: 'PO', customerName: 'Jane Doe', date: '2026-01-01', stationName: 'Rankin' },
+  queuedAt: 1,
+  ...overrides,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsActuallyOnline.mockResolvedValue(true)
+  // Default: both the receipt upload and the PO create succeed.
+  mockAxiosPost.mockImplementation((url: string) => {
+    if (url.includes('upload-base64')) return Promise.resolve({ data: { filename: 'uploaded.jpg' } })
+    return Promise.resolve({ status: 201, data: { _id: 'txn-1' } })
+  })
+})
+
+describe('syncPendingActions — per-key delete, no blanket clear', () => {
+  it('deletes a successfully-synced action individually by its key', async () => {
+    mockGetPendingActionEntries
+      .mockResolvedValueOnce([{ key: 1, action: poAction() }])
+      .mockResolvedValueOnce([]) // next pass: nothing left, loop terminates
+
+    await syncPendingActions()
+
+    expect(mockAxiosPost).toHaveBeenCalledWith(
+      '/api/purchase-orders',
+      expect.objectContaining({ receipt: 'uploaded.jpg' }),
+      expect.any(Object)
+    )
+    expect(mockDeletePendingAction).toHaveBeenCalledWith(1)
+    expect(mockDeletePendingAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('picks up an action added concurrently during a sync pass instead of losing it', async () => {
+    // Simulates: item 1 exists at the start; item 2 gets queued by other
+    // code (e.g. a second PO submitted) while item 1 is being processed.
+    // A fresh read each pass means item 2 is picked up on the next pass
+    // instead of being wiped by a blanket clear-the-whole-store call.
+    mockGetPendingActionEntries
+      .mockResolvedValueOnce([{ key: 1, action: poAction() }])
+      .mockResolvedValueOnce([{ key: 2, action: poAction({ payload: { ...poAction().payload, customerName: 'Second' } }) }])
+      .mockResolvedValueOnce([])
+
+    await syncPendingActions()
+
+    expect(mockDeletePendingAction).toHaveBeenCalledWith(1)
+    expect(mockDeletePendingAction).toHaveBeenCalledWith(2)
+    expect(mockAxiosPost.mock.calls.filter(([url]) => url === '/api/purchase-orders')).toHaveLength(2)
+  })
+})
+
+describe('syncPendingActions — retryable vs. permanent failure classification', () => {
+  it('marks a 403 (permission denied) as permanently failed and does not retry it on a later call', async () => {
+    const err403 = Object.assign(new Error('Forbidden'), {
+      isAxiosErr: true,
+      response: { status: 403, data: { message: 'Permission denied' } },
+    })
+    mockAxiosPost.mockImplementation((url: string) => {
+      if (url.includes('upload-base64')) return Promise.resolve({ data: { filename: 'uploaded.jpg' } })
+      return Promise.reject(err403)
+    })
+    mockGetPendingActionEntries
+      .mockResolvedValueOnce([{ key: 5, action: poAction() }])
+      .mockResolvedValueOnce([]) // failed entries are excluded from "actionable" on the next pass
+
+    await syncPendingActions()
+
+    expect(mockUpdatePendingAction).toHaveBeenCalledWith(5, expect.objectContaining({
+      failed: true,
+      failureReason: 'Permission denied',
+    }))
+    expect(mockDeletePendingAction).not.toHaveBeenCalled()
+
+    // A later call sees the entry already marked failed — it must be
+    // excluded from "actionable" and never retried.
+    mockGetPendingActionEntries.mockReset()
+    mockGetPendingActionEntries.mockResolvedValue([{ key: 5, action: poAction({ failed: true }) }])
+    mockAxiosPost.mockClear()
+
+    await syncPendingActions()
+
+    expect(mockAxiosPost).not.toHaveBeenCalledWith('/api/purchase-orders', expect.any(Object), expect.any(Object))
+  })
+
+  it('marks a 409 (duplicate PO number) as permanently failed', async () => {
+    const err409 = Object.assign(new Error('Conflict'), {
+      isAxiosErr: true,
+      response: { status: 409, data: { message: 'PO number already exists.' } },
+    })
+    mockAxiosPost.mockImplementation((url: string) => {
+      if (url.includes('upload-base64')) return Promise.resolve({ data: { filename: 'uploaded.jpg' } })
+      return Promise.reject(err409)
+    })
+    mockGetPendingActionEntries
+      .mockResolvedValueOnce([{ key: 8, action: poAction() }])
+      .mockResolvedValueOnce([])
+
+    await syncPendingActions()
+
+    expect(mockUpdatePendingAction).toHaveBeenCalledWith(8, expect.objectContaining({
+      failed: true,
+      failureReason: 'PO number already exists.',
+    }))
+  })
+
+  it('leaves a network/timeout failure (no response at all) queued for retry', async () => {
+    const networkErr = Object.assign(new Error('Network Error'), { isAxiosErr: true })
+    mockAxiosPost.mockImplementation((url: string) => {
+      if (url.includes('upload-base64')) return Promise.reject(networkErr)
+      return Promise.resolve({ status: 201, data: {} })
+    })
+    mockGetPendingActionEntries.mockResolvedValue([{ key: 9, action: poAction() }])
+
+    await syncPendingActions()
+
+    expect(mockUpdatePendingAction).not.toHaveBeenCalled()
+    expect(mockDeletePendingAction).not.toHaveBeenCalled()
+  })
+
+  it('leaves a 500 failure queued for retry, not marked permanently failed', async () => {
+    const err500 = Object.assign(new Error('Server Error'), { isAxiosErr: true, response: { status: 500 } })
+    mockAxiosPost.mockImplementation((url: string) => {
+      if (url.includes('upload-base64')) return Promise.resolve({ data: { filename: 'uploaded.jpg' } })
+      return Promise.reject(err500)
+    })
+    mockGetPendingActionEntries.mockResolvedValue([{ key: 3, action: poAction() }])
+
+    await syncPendingActions()
+
+    expect(mockUpdatePendingAction).not.toHaveBeenCalled()
+    expect(mockDeletePendingAction).not.toHaveBeenCalled()
+  })
+})
+
+describe('syncPendingActions — overlapping-call guard', () => {
+  it('collapses a second concurrent call into a no-op instead of double-processing', async () => {
+    let resolveEntries: (v: any) => void = () => {}
+    const entriesPromise = new Promise((r) => { resolveEntries = r })
+    mockGetPendingActionEntries.mockImplementation(() => entriesPromise)
+
+    const p1 = syncPendingActions()
+    const p2 = syncPendingActions() // should short-circuit immediately — syncInFlight is already true
+
+    // p1's loop has its own internal 300ms delay before it calls
+    // getPendingActionEntries() for the first time — wait for that to
+    // actually happen before resolving, otherwise resolveEntries() would
+    // still be the pre-assignment no-op and p1 would hang forever.
+    await vi.waitFor(() => expect(mockGetPendingActionEntries).toHaveBeenCalled(), { timeout: 2000 })
+    resolveEntries([])
+
+    await Promise.all([p1, p2])
+
+    expect(mockGetPendingActionEntries).toHaveBeenCalledTimes(1)
+  }, 10000)
+})
+
+describe('triggerBackgroundSync', () => {
+  it('does not attempt to sync when isActuallyOnline resolves false', async () => {
+    mockIsActuallyOnline.mockResolvedValue(false)
+
+    await triggerBackgroundSync()
+
+    expect(mockGetPendingActionEntries).not.toHaveBeenCalled()
+  })
+
+  it('syncs when isActuallyOnline resolves true', async () => {
+    mockIsActuallyOnline.mockResolvedValue(true)
+    mockGetPendingActionEntries.mockResolvedValue([])
+
+    await triggerBackgroundSync()
+
+    expect(mockGetPendingActionEntries).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/orderRecIndexedDB.ts
+++ b/frontend/src/lib/orderRecIndexedDB.ts
@@ -41,13 +41,53 @@ export const savePendingAction = async (action: any) => {
   await tx.done;
 };
 
-// ✅ Get all pending actions
-export const getPendingActions = async () => {
+// Enumerate pending actions together with their real IndexedDB keys, so a
+// single entry can be deleted/patched without disturbing the rest of the
+// queue. The store is autoIncrement (no keyPath), so getAll() alone never
+// surfaces keys — getAllKeys() does, in the same result order.
+export const getPendingActionEntries = async (): Promise<{ key: number; action: any }[]> => {
   const db = await getDB();
-  return db.getAll(PENDING_STORE);
+  const tx = db.transaction(PENDING_STORE, 'readonly');
+  const keys = await tx.store.getAllKeys();
+  const actions = await tx.store.getAll();
+  await tx.done;
+  return keys.map((key, i) => ({ key: key as number, action: actions[i] }));
 };
 
-// ✅ Clear all pending actions after successful sync
+// Delete exactly one pending action by its IndexedDB key. Prefer this over
+// clearPendingActions() when acting on specific entries — a blanket clear()
+// can silently drop actions queued concurrently by other code.
+export const deletePendingAction = async (key: number): Promise<void> => {
+  const db = await getDB();
+  const tx = db.transaction(PENDING_STORE, 'readwrite');
+  await tx.store.delete(key);
+  await tx.done;
+};
+
+// Patch a single pending action in place (e.g. to mark a permanent sync
+// failure) without touching its key or any other queued entry.
+export const updatePendingAction = async (key: number, patch: Record<string, any>): Promise<void> => {
+  const db = await getDB();
+  const tx = db.transaction(PENDING_STORE, 'readwrite');
+  const existing = await tx.store.get(key);
+  if (existing) {
+    await tx.store.put({ ...existing, ...patch }, key);
+  }
+  await tx.done;
+};
+
+// ✅ Get all pending actions. Each object additively includes `_key` (its
+// IndexedDB key) so callers that need to delete/patch a specific entry
+// (e.g. dismissing one failed purchase order) can do so via
+// deletePendingAction/updatePendingAction without affecting the rest.
+export const getPendingActions = async () => {
+  const entries = await getPendingActionEntries();
+  return entries.map(({ key, action }) => ({ ...action, _key: key }));
+};
+
+// Clear all pending actions. Kept for compatibility, but prefer
+// deletePendingAction(key) for anything acting on specific entries — this
+// wipes the entire store, which can drop actions added concurrently.
 export const clearPendingActions = async () => {
   const db = await getDB();
   const tx = db.transaction(PENDING_STORE, 'readwrite');
@@ -66,7 +106,10 @@ export const hasPendingActionsForId = async (orderId: string) => {
   const db = await getDB();
   const actions = await db.getAll(PENDING_STORE);
 
-  return actions.some(a => a.orderId === orderId);
+  // Exclude permanently-failed entries — otherwise a 403/404 on a TOGGLE_ITEM
+  // would leave this flag set forever, permanently blocking this order from
+  // ever refreshing from the server again.
+  return actions.some(a => a.orderId === orderId && !a.failed);
 };
 
 // delete any pending actions for a order rec if order is deleted

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -3,7 +3,8 @@ import { twMerge } from "tailwind-merge"
 import { domain } from "@/lib/constants"
 import { jwtDecode } from "jwt-decode"
 import axios from "axios"
-import { getDB, clearPendingActions, saveOrderRec } from "@/lib/orderRecIndexedDB"
+import { getPendingActionEntries, deletePendingAction, updatePendingAction, saveOrderRec } from "@/lib/orderRecIndexedDB"
+import { isActuallyOnline } from "@/lib/network"
 // import { useAuth } from "@/context/AuthContext";
 
 export function cn(...inputs: ClassValue[]) {
@@ -416,109 +417,162 @@ export function camelCaseToCapitalized(text: String) {
     .join(' ');
 }
 
-//function for syncing order rec with the mongo db
-export async function syncPendingActions() {
-    let pending;
+// Replays a single queued action against the backend. Shared by
+// syncPendingActions()'s loop below — kept as its own function so the loop
+// body stays readable.
+async function syncOneAction(action: any): Promise<void> {
+  const authHeader = { Authorization: `Bearer ${localStorage.getItem("token")}` };
 
-    do {
+  if (action.type === "TOGGLE_ITEM") {
+    await axios.put(
+      `/api/order-rec/${action.orderId}/item/${action.catIdx}/${action.itemIdx}`,
+      { completed: action.completed, isChanged: action.isChanged },
+      { headers: authHeader }
+    );
+    const res = await axios.get(`/api/order-rec/${action.orderId}`, { headers: authHeader });
+    const latest = { ...res.data, id: res.data._id, _id: res.data._id };
+    await saveOrderRec(latest);
+    console.log("✅ Synced and refreshed TOGGLE_ITEM order record:", latest.id);
+  }
+
+  else if (action.type === "UPDATE_ORDER_REC") {
+    const orderId = action.id;
+    const res = await axios.put(
+      `/api/order-rec/${orderId}`,
+      { categories: action.payload.categories },
+      { headers: authHeader }
+    );
+    const latest = { ...res.data, id: res.data._id, _id: res.data._id };
+    await saveOrderRec(latest);
+    console.log("✅ Synced and refreshed UPDATE_ORDER_REC order record:", latest.id);
+  }
+
+  else if (action.type === "CREATE_PURCHASE_ORDER") {
+    const { filename } = await uploadBase64Image(action.receipt, "receipt.jpg");
+    await axios.post(
+      "/api/purchase-orders",
+      { ...action.payload, receipt: filename },
+      { headers: { ...authHeader, "X-Required-Permission": "po" } }
+    );
+    console.log("✅ Synced CREATE_PURCHASE_ORDER for", action.payload?.customerName);
+  }
+
+  else if (action.type === "SAVE_EXTRA_NOTE") {
+    const res = await axios.patch(
+      `/api/order-rec/${action.orderId}`,
+      { extraItemsNote: action.note },
+      { headers: authHeader }
+    );
+    const latest = { ...res.data, id: res.data._id, _id: res.data._id };
+    await saveOrderRec(latest);
+    console.log("✅ Synced and refreshed SAVE_EXTRA_NOTE order record:", latest.id);
+  }
+
+  else {
+    throw new Error(`Unknown pending action type: ${action.type}`);
+  }
+}
+
+// HTTP failures that will NEVER succeed no matter how many times we retry —
+// e.g. 403 (permission denied) and 409 (duplicate PO number, see
+// backend/routes/purchaseOrder.js). Leaving these queued forever would mean
+// a silent, unexplained "pending" limbo with no path to resolution.
+// Everything else (no response at all = network/timeout, 5xx, 408, 429) is
+// transient and stays queued for the next pass.
+function isPermanentFailure(err: unknown): boolean {
+  if (axios.isAxiosError(err)) {
+    const status = err.response?.status;
+    if (status == null) return false; // network/timeout — retryable
+    if (status === 408 || status === 429) return false; // explicitly transient
+    return status >= 400 && status < 500;
+  }
+  // A non-axios error means our own sync code threw (e.g. an unrecognized
+  // action.type) — retrying won't fix that either.
+  return true;
+}
+
+function describeSyncFailure(err: unknown): string {
+  if (axios.isAxiosError(err)) {
+    return err.response?.data?.message || err.message || "Sync failed.";
+  }
+  return err instanceof Error ? err.message : "Sync failed.";
+}
+
+// Guards against overlapping sync passes — syncPendingActions() can now be
+// triggered from multiple places close together (a submit's own
+// triggerBackgroundSync(), the navbar's `online` listener, and its 15s
+// poll), and without this a fast-firing pair of calls could both pick up
+// the same pending action and, e.g., upload the same receipt photo twice.
+let syncInFlight = false;
+
+//function for syncing queued offline actions (order rec + purchase orders) with the backend
+export async function syncPendingActions() {
+  if (syncInFlight) {
+    console.log("🛰️ Sync already in progress — skipping overlapping call");
+    return;
+  }
+  syncInFlight = true;
+
+  try {
+    // Loops passes until a pass makes zero progress (nothing left to sync,
+    // or everything remaining is a transient failure) — re-reading the
+    // queue fresh every pass means anything queued concurrently (e.g. a
+    // second PO submitted mid-sync) is picked up instead of lost, unlike
+    // the previous snapshot+clear()-the-whole-store design.
+    while (true) {
       await new Promise(res => setTimeout(res, 300));
 
-      const db = await getDB();
-      const tx = db.transaction("pendingActions", "readonly");
-      pending = await tx.store.getAll();
+      const entries = await getPendingActionEntries();
+      const actionable = entries.filter(({ action }) => !action.failed);
+      if (!actionable.length) break;
 
-      if (!pending.length) break;
+      console.log(`🛰️ Syncing ${actionable.length} pending actions...`);
+      let madeProgress = false;
 
-      console.log(`🛰️ Syncing ${pending.length} pending actions...`);
-      const failed: any[] = [];
-
-      for (const action of pending) {
+      for (const { key, action } of actionable) {
         try {
-          if (action.type === "TOGGLE_ITEM") {
-            // 🔹 Perform backend update
-            await axios.put(
-              `/api/order-rec/${action.orderId}/item/${action.catIdx}/${action.itemIdx}`,
-              { completed: action.completed, isChanged: action.isChanged },
-              { headers: { Authorization: `Bearer ${localStorage.getItem("token")}` } }
-            );
-
-            // 🔹 Fetch the latest record from backend and cache it
-            const res = await axios.get(`/api/order-rec/${action.orderId}`, {
-              headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
-            });
-            const latest = { ...res.data, id: res.data._id, _id: res.data._id };
-            await saveOrderRec(latest);
-
-            console.log("✅ Synced and refreshed TOGEL_ITEM order record:", latest.id);
-          }
-
-          else if (action.type === "UPDATE_ORDER_REC") {
-            const orderId = action.id;
-            const res = await axios.put(
-              `/api/order-rec/${orderId}`,
-              { categories: action.payload.categories },
-              { headers: { Authorization: `Bearer ${localStorage.getItem("token")}` } }
-            );
-
-            const latest = { ...res.data, id: res.data._id, _id: res.data._id  };
-            await saveOrderRec(latest);
-            console.log("✅ Synced and refreshed UPDATE_ORDER_REC order record:", latest.id);
-          }
-
-          else if (action.type === "CREATE_PURCHASE_ORDER") {
-            const { filename } = await uploadBase64Image(action.receipt, "receipt.jpg");
-
-            await axios.post(
-              "/api/purchase-orders",
-              { ...action.payload, receipt: filename },
-              {
-                headers: {
-                  Authorization: `Bearer ${localStorage.getItem("token")}`,
-                  "X-Required-Permission": "po",
-                },
-              }
-            );
-
-            console.log("✅ Synced CREATE_PURCHASE_ORDER for", action.payload?.customerName);
-          }
-
-          else if (action.type === "SAVE_EXTRA_NOTE") {
-            // 🔹 Perform backend update
-            const res = await axios.patch(
-              `/api/order-rec/${action.orderId}`,
-              { extraItemsNote: action.note },
-              { headers: { Authorization: `Bearer ${localStorage.getItem("token")}` } }
-            );
-
-            // 🔹 Fetch latest record from backend and cache it
-            // const res = await axios.get(`/api/order-rec/${action.orderId}`, {
-            //   headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
-            // });
-            const latest = { ...res.data, id: res.data._id, _id: res.data._id };
-            await saveOrderRec(latest);
-            console.log("✅ Synced and refreshed SAVE_EXTRA_NOTE order record:", latest.id);
-          }
-
+          await syncOneAction(action);
+          await deletePendingAction(key); // remove ONLY this entry
+          madeProgress = true;
         } catch (err) {
-          console.error("⚠️ Failed syncing", action, err);
-          failed.push(action);
+          if (isPermanentFailure(err)) {
+            await updatePendingAction(key, {
+              failed: true,
+              failureReason: describeSyncFailure(err),
+              failedAt: Date.now(),
+            });
+            madeProgress = true; // resolved into a terminal state, not stuck
+            console.error("🛑 Permanent failure, will not retry:", action.type, key, err);
+          } else {
+            console.warn("⚠️ Transient failure, left queued for retry:", action.type, key, err);
+          }
         }
       }
 
-      // ✅ Clear successful ones
-      await clearPendingActions();
-
-      // 🔁 Requeue failed ones
-      if (failed.length) {
-        const dbw = await getDB();
-        const txw = dbw.transaction("pendingActions", "readwrite");
-        for (const f of failed) await txw.store.add(f);
-        await txw.done;
-        console.warn(`🔁 ${failed.length} actions retained for retry`);
-        break;
-      }
-    } while (pending.length > 0);
-
-    console.log("✅ Pending sync done");
+      // Nothing changed this pass — whatever's left is a transient failure
+      // that just failed again. Stop instead of hot-looping; the next
+      // `online` event / 15s poll / triggerBackgroundSync() call retries.
+      if (!madeProgress) break;
+    }
+  } finally {
+    syncInFlight = false;
   }
+
+  console.log("✅ Pending sync pass done");
+}
+
+// Best-effort background sync trigger, meant to be called WITHOUT awaiting
+// (fire-and-forget). isActuallyOnline() can itself take up to ~12s on a
+// degraded connection, but since callers don't await this, that delay is
+// invisible to them — it only affects how soon a genuinely-online user's
+// queued item leaves the "pending" state.
+export async function triggerBackgroundSync(): Promise<void> {
+  try {
+    if (await isActuallyOnline()) {
+      await syncPendingActions();
+    }
+  } catch (err) {
+    console.warn("Background sync attempt failed to start:", err);
+  }
+}
 

--- a/frontend/src/routes/_navbarLayout/__tests__/po.test.tsx
+++ b/frontend/src/routes/_navbarLayout/__tests__/po.test.tsx
@@ -19,6 +19,8 @@ const {
   mockIsActuallyOnline,
   mockSavePendingAction,
   mockGetPendingActions,
+  mockTriggerBackgroundSync,
+  mockDeletePendingAction,
 } = vi.hoisted(() => {
   const mockStore = {
     fleetCardNumber: '' as string,
@@ -84,6 +86,8 @@ const {
     mockIsActuallyOnline: vi.fn().mockResolvedValue(true),
     mockSavePendingAction: vi.fn().mockResolvedValue(undefined),
     mockGetPendingActions: vi.fn().mockResolvedValue([]),
+    mockTriggerBackgroundSync: vi.fn().mockResolvedValue(undefined),
+    mockDeletePendingAction: vi.fn().mockResolvedValue(undefined),
   }
 })
 
@@ -140,6 +144,7 @@ vi.mock('@/lib/utils', async (importOriginal) => {
     }),
     uploadBase64Image: mockUploadBase64Image,
     formatFleetCardNumber: (num: string) => num || '',
+    triggerBackgroundSync: mockTriggerBackgroundSync,
   }
 })
 
@@ -157,6 +162,9 @@ vi.mock('@/lib/orderRecIndexedDB', () => ({
   getOrderRecById: vi.fn(),
   savePendingAction: mockSavePendingAction,
   getPendingActions: mockGetPendingActions,
+  getPendingActionEntries: vi.fn().mockResolvedValue([]),
+  deletePendingAction: mockDeletePendingAction,
+  updatePendingAction: vi.fn().mockResolvedValue(undefined),
   clearPendingActions: vi.fn(),
   hasPendingActionsForId: vi.fn().mockResolvedValue(false),
   deletePendingActionsForId: vi.fn(),
@@ -654,7 +662,7 @@ describe('PO List — list.tsx', () => {
     await waitFor(() => expect(screen.getByText('Jane Doe')).toBeInTheDocument())
   })
 
-  it('shows a queued purchase order from the offline sync queue as "Pending sync"', async () => {
+  it('shows a queued purchase order from the offline sync queue as "Pending upload"', async () => {
     mockAxiosGet.mockResolvedValue({ status: 200, data: [] })
     mockGetPendingActions.mockResolvedValueOnce([
       {
@@ -683,7 +691,45 @@ describe('PO List — list.tsx', () => {
     renderWithSuspense(<POList />)
 
     await waitFor(() => expect(screen.getByText('Offline Customer')).toBeInTheDocument())
-    expect(screen.getAllByText(/pending sync/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/pending upload/i).length).toBeGreaterThan(0)
+  })
+
+  it('shows a permanently-failed purchase order with red/error styling and its reason, separate from the pending count', async () => {
+    mockAxiosGet.mockResolvedValue({ status: 200, data: [] })
+    mockGetPendingActions.mockResolvedValueOnce([
+      {
+        type: 'CREATE_PURCHASE_ORDER',
+        queuedAt: 54321,
+        receipt: 'data:image/png;base64,failed',
+        failed: true,
+        failureReason: 'PO number already exists.',
+        _key: 7,
+        payload: {
+          source: 'PO',
+          date: '2026-01-01',
+          stationName: 'Rankin',
+          fleetCardNumber: '',
+          poNumber: '11111',
+          quantity: 10,
+          amount: 20,
+          productCode: 'UNL',
+          customerName: 'Failed Customer',
+          driverName: 'Failed Driver',
+          vehicleMakeModel: '',
+          licensePlate: '',
+          purchaseType: 'fuel',
+          itemsDescription: '',
+        },
+      },
+    ])
+
+    renderWithSuspense(<POList />)
+
+    await waitFor(() => expect(screen.getByText('Failed Customer')).toBeInTheDocument())
+    expect(screen.getByText(/upload failed/i)).toBeInTheDocument()
+    expect(screen.getByText('PO number already exists.')).toBeInTheDocument()
+    // Not counted as "pending upload" — it's terminal, not in progress.
+    expect(screen.queryByText(/pending upload/i)).not.toBeInTheDocument()
   })
 })
 
@@ -760,7 +806,6 @@ describe('PO Receipt — receipt.tsx', () => {
     mockUseAuth.mockReturnValue({
       user: { id: 'u1', location: 'Rankin', timezone: 'America/Toronto', access: {} },
     })
-    mockAxiosPost.mockResolvedValue({ status: 201, data: { _id: 'txn-2' } })
   })
 
   it('redirects to /po when required form fields are missing', async () => {
@@ -801,60 +846,15 @@ describe('PO Receipt — receipt.tsx', () => {
     expect(submitBtn).toBeDisabled()
   })
 
-  it('calls POST /api/purchase-orders and navigates to /po/list on success', async () => {
-    renderWithQuery(<POReceipt />)
+  // The submit handler no longer makes any network call at all — it always
+  // saves locally first (see receipt.tsx). These tests replace the old
+  // ones that exercised a live axios.post path, which no longer exists.
 
-    const submitBtn = screen.getByRole('button', { name: /finalize|submit/i })
-    fireEvent.click(submitBtn)
-
-    await waitFor(() =>
-      expect(mockAxiosPost).toHaveBeenCalledWith(
-        expect.stringContaining('/api/purchase-orders'),
-        expect.objectContaining({ source: 'PO', signature: '', vehicleMakeModel: 'Ford F-150', licensePlate: '' }),
-        expect.any(Object)
-      )
-    )
-    await waitFor(() =>
-      expect(mockNavigate).toHaveBeenCalledWith({ to: '/po/list' })
-    )
-  })
-
-  it('bounds the PO submit request with a timeout, so a false "online" reading cannot hang forever', async () => {
-    renderWithQuery(<POReceipt />)
-
-    const submitBtn = screen.getByRole('button', { name: /finalize|submit/i })
-    fireEvent.click(submitBtn)
-
-    await waitFor(() =>
-      expect(mockAxiosPost).toHaveBeenCalledWith(
-        expect.stringContaining('/api/purchase-orders'),
-        expect.any(Object),
-        expect.objectContaining({ timeout: expect.any(Number) })
-      )
-    )
-  })
-
-  it('sends date as a plain "yyyy-MM-dd" string, not a full datetime', async () => {
-    renderWithQuery(<POReceipt />)
-
-    const submitBtn = screen.getByRole('button', { name: /finalize|submit/i })
-    fireEvent.click(submitBtn)
-
-    await waitFor(() =>
-      expect(mockAxiosPost).toHaveBeenCalledWith(
-        expect.stringContaining('/api/purchase-orders'),
-        expect.objectContaining({ date: '2026-01-15' }),
-        expect.any(Object)
-      )
-    )
-  })
-
-  it('queues the purchase order for offline sync instead of posting when offline', async () => {
-    mockIsActuallyOnline.mockResolvedValueOnce(false)
+  it('always saves the purchase order to the local queue immediately, regardless of connectivity', async () => {
     // A blocking window.alert() freezes the tab's repaint until dismissed —
     // on a device with no visible dialog chrome that looks identical to the
-    // submit being permanently stuck on "Saving...". Confirm the offline
-    // success path never calls it (regression test for that exact bug).
+    // submit being permanently stuck on "Saving...". Confirm the success
+    // path never calls it (regression test for that exact bug).
     const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
 
     renderWithQuery(<POReceipt />)
@@ -871,18 +871,43 @@ describe('PO Receipt — receipt.tsx', () => {
         })
       )
     )
-    expect(mockAxiosPost).not.toHaveBeenCalled()
-    expect(mockUploadBase64Image).not.toHaveBeenCalled()
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith({ to: '/po/list' }))
     expect(alertSpy).not.toHaveBeenCalled()
 
     alertSpy.mockRestore()
   })
 
-  it('falls back to the offline queue when the network request cannot reach the server', async () => {
-    const networkError = Object.assign(new Error('Network Error'), { isAxiosErr: true })
-    mockAxiosPost.mockRejectedValueOnce(networkError)
+  it('never calls axios/uploadBase64Image directly, even when isActuallyOnline resolves true', async () => {
+    mockIsActuallyOnline.mockResolvedValue(true)
 
+    renderWithQuery(<POReceipt />)
+
+    const submitBtn = screen.getByRole('button', { name: /finalize|submit/i })
+    fireEvent.click(submitBtn)
+
+    await waitFor(() => expect(mockSavePendingAction).toHaveBeenCalled())
+    expect(mockAxiosPost).not.toHaveBeenCalled()
+    expect(mockUploadBase64Image).not.toHaveBeenCalled()
+  })
+
+  it('triggers a background sync attempt after queuing, without blocking navigation', async () => {
+    // Never resolves — proves navigation doesn't wait on this at all, which
+    // is the concrete regression test for the stuck-"Saving..." bug: the fix
+    // isn't "make the network check faster," it's "don't have one in the
+    // critical path at all."
+    mockTriggerBackgroundSync.mockReturnValue(new Promise(() => {}))
+
+    renderWithQuery(<POReceipt />)
+
+    const submitBtn = screen.getByRole('button', { name: /finalize|submit/i })
+    fireEvent.click(submitBtn)
+
+    await waitFor(() => expect(mockSavePendingAction).toHaveBeenCalled())
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith({ to: '/po/list' }))
+    expect(mockTriggerBackgroundSync).toHaveBeenCalled()
+  })
+
+  it('sends date as a plain "yyyy-MM-dd" string, not a full datetime', async () => {
     renderWithQuery(<POReceipt />)
 
     const submitBtn = screen.getByRole('button', { name: /finalize|submit/i })
@@ -890,9 +915,19 @@ describe('PO Receipt — receipt.tsx', () => {
 
     await waitFor(() =>
       expect(mockSavePendingAction).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'CREATE_PURCHASE_ORDER' })
+        expect.objectContaining({ payload: expect.objectContaining({ date: '2026-01-15' }) })
       )
     )
-    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith({ to: '/po/list' }))
+  })
+
+  it('double-clicking Finalize & Submit only queues one pending action', async () => {
+    renderWithQuery(<POReceipt />)
+
+    const submitBtn = screen.getByRole('button', { name: /finalize|submit/i })
+    fireEvent.click(submitBtn)
+    fireEvent.click(submitBtn)
+
+    await waitFor(() => expect(mockSavePendingAction).toHaveBeenCalled())
+    expect(mockSavePendingAction).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/routes/_navbarLayout/po/list.tsx
+++ b/frontend/src/routes/_navbarLayout/po/list.tsx
@@ -8,7 +8,7 @@ import { LocationPicker } from '@/components/custom/locationPicker'
 import PurchaseOrderPDF from '@/components/custom/poForm'
 import { pdf } from '@react-pdf/renderer'
 import { Button } from '@/components/ui/button'
-import { Trash2, Camera, Loader2, Calendar } from 'lucide-react'
+import { Trash2, Camera, Loader2, Calendar, AlertTriangle } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
 import { getStartAndEndOfToday, uploadBase64Image } from '@/lib/utils'
@@ -16,7 +16,7 @@ import axios from "axios"
 import { useAuth } from "@/context/AuthContext";
 import { useSite } from "@/context/SiteContext";
 import { formatFleetCardNumber } from '@/lib/utils';
-import { getPendingActions } from '@/lib/orderRecIndexedDB';
+import { getPendingActions, deletePendingAction } from '@/lib/orderRecIndexedDB';
 
 export const Route = createFileRoute('/_navbarLayout/po/list')({
   component: RouteComponent,
@@ -135,33 +135,52 @@ function RouteComponent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingPOs.length]);
 
-  const pendingRows = pendingPOs
+  const filteredPendingActions = pendingPOs
     .filter((a: any) => a?.payload?.stationName === stationName)
     .filter((a: any) => {
       if (!date?.from || !date?.to) return true;
       const d = a?.payload?.date;
       return d && d >= toYmd(date.from) && d <= toYmd(date.to);
-    })
-    .map((a: any) => ({
-      _id: `pending-${a.queuedAt}`,
-      date: a.payload.date,
-      dateStr: a.payload.date,
-      fleetCardNumber: a.payload.fleetCardNumber,
-      poNumber: a.payload.poNumber,
-      customerName: a.payload.customerName,
-      driverName: a.payload.driverName,
-      quantity: a.payload.quantity,
-      amount: a.payload.amount,
-      description: a.payload.purchaseType === 'non-fuel' ? a.payload.itemsDescription : a.payload.productCode,
-      vehicleMakeModel: a.payload.vehicleMakeModel,
-      licensePlate: a.payload.licensePlate,
-      signature: a.payload.signature,
-      receipt: '',
-      requestReceipt: false,
-      pending: true as const,
-    }));
+    });
 
-  const allOrders = [...pendingRows, ...purchaseOrders];
+  const mapPendingAction = (a: any) => ({
+    _id: `pending-${a.queuedAt}`,
+    date: a.payload.date,
+    dateStr: a.payload.date,
+    fleetCardNumber: a.payload.fleetCardNumber,
+    poNumber: a.payload.poNumber,
+    customerName: a.payload.customerName,
+    driverName: a.payload.driverName,
+    quantity: a.payload.quantity,
+    amount: a.payload.amount,
+    description: a.payload.purchaseType === 'non-fuel' ? a.payload.itemsDescription : a.payload.productCode,
+    vehicleMakeModel: a.payload.vehicleMakeModel,
+    licensePlate: a.payload.licensePlate,
+    signature: a.payload.signature,
+    receipt: '',
+    requestReceipt: false,
+    pending: !a.failed,
+    failed: !!a.failed,
+    failureReason: a.failureReason,
+    _key: a._key,
+  });
+
+  // Permanently-failed submissions (e.g. 403 permission denied, 409
+  // duplicate PO number) will never succeed no matter how many times the
+  // background sync retries — surfaced separately so they don't sit as an
+  // unexplained "pending" spinner forever.
+  const pendingRows = filteredPendingActions.filter((a: any) => !a.failed).map(mapPendingAction);
+  const failedRows = filteredPendingActions.filter((a: any) => a.failed).map(mapPendingAction);
+
+  const allOrders = [...failedRows, ...pendingRows, ...purchaseOrders];
+
+  const dismissFailedPO = async (key: any) => {
+    if (key == null) return;
+    const ok = window.confirm('Remove this failed purchase order from the queue? It was never submitted — re-enter it manually if it still needs to be recorded.');
+    if (!ok) return;
+    await deletePendingAction(key);
+    refreshPendingPOs();
+  };
 
   const generatePDF = async (order: {
     date: string;
@@ -328,7 +347,7 @@ function RouteComponent() {
     }
   }
 
-  const showActionsColumn = !!(access?.po?.pdf || access?.po?.changeDate || access?.po?.delete || purchaseOrders.some(o => o.requestReceipt) || pendingRows.length > 0)
+  const showActionsColumn = !!(access?.po?.pdf || access?.po?.changeDate || access?.po?.delete || purchaseOrders.some(o => o.requestReceipt) || pendingRows.length > 0 || failedRows.length > 0)
 
   return (
     <div className="p-4 border border-dashed border-gray-300 rounded-md">
@@ -357,7 +376,10 @@ function RouteComponent() {
         <span>
           {allOrders.length} {allOrders.length === 1 ? 'entry' : 'entries'}
           {pendingRows.length > 0 && (
-            <span className="text-amber-600"> ({pendingRows.length} pending sync)</span>
+            <span className="text-amber-600"> ({pendingRows.length} pending upload)</span>
+          )}
+          {failedRows.length > 0 && (
+            <span className="text-red-600"> ({failedRows.length} failed)</span>
           )}
         </span>
         <span>Qty: {allOrders.reduce((sum, o) => sum + o.quantity, 0).toFixed(3)}</span>
@@ -383,7 +405,7 @@ function RouteComponent() {
         <tbody>
           {allOrders.length > 0 ? (
             allOrders.map((order: any, index) => (
-              <tr key={order._id ?? index} className={order.pending ? 'bg-amber-50 hover:bg-amber-100' : 'hover:bg-gray-50'}>
+              <tr key={order._id ?? index} className={order.failed ? 'bg-red-50 hover:bg-red-100' : order.pending ? 'bg-amber-50 hover:bg-amber-100' : 'hover:bg-gray-50'}>
                 <td className="border-dashed border-t border-gray-300 px-4 py-2">{
                   order.dateStr || new Date(order.date).toLocaleDateString('en-CA', { timeZone: 'UTC' })
                 }</td>
@@ -396,10 +418,30 @@ function RouteComponent() {
                 <td className="border-dashed border-t border-gray-300 px-4 py-2">{order.licensePlate}</td>
                 {showActionsColumn && (
                   <td className="border-dashed border-t border-gray-300 px-4 py-2 space-x-2">
-                    {order.pending ? (
+                    {order.failed ? (
+                      <span className="text-xs font-medium text-red-700 inline-flex flex-col items-start gap-0.5">
+                        <span className="inline-flex items-center gap-1">
+                          <AlertTriangle className="h-3 w-3" />
+                          Upload failed
+                        </span>
+                        {order.failureReason && (
+                          <span className="text-[10px] text-red-600 max-w-[180px] truncate" title={order.failureReason}>
+                            {order.failureReason}
+                          </span>
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-1 text-[10px] text-red-700"
+                          onClick={() => dismissFailedPO(order._key)}
+                        >
+                          Dismiss
+                        </Button>
+                      </span>
+                    ) : order.pending ? (
                       <span className="text-xs font-medium text-amber-700 inline-flex items-center gap-1">
                         <Loader2 className="h-3 w-3 animate-spin" />
-                        Pending sync
+                        Pending upload
                       </span>
                     ) : (
                       <>

--- a/frontend/src/routes/_navbarLayout/po/receipt.tsx
+++ b/frontend/src/routes/_navbarLayout/po/receipt.tsx
@@ -1,14 +1,9 @@
-import axios from "axios";
-import { useMutation } from "@tanstack/react-query";
-import { uploadBase64Image } from "@/lib/utils";
-import { isActuallyOnline } from "@/lib/network";
 import { savePendingAction } from "@/lib/orderRecIndexedDB";
-import { domain } from "@/lib/constants";
+import { triggerBackgroundSync } from "@/lib/utils";
 import { Camera, Loader2 } from "lucide-react";
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { useRef } from 'react'
 // import Webcam from "react-webcam"
 import { useFormStore } from '@/store'
 import { Button } from '@/components/ui/button'
@@ -20,7 +15,6 @@ export const Route = createFileRoute('/_navbarLayout/po/receipt')({
 
 function RouteComponent() {
   const navigate = useNavigate();
-  // const webcamRef = useRef<Webcam>(null);
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const setReceipt = useFormStore((state) => state.setReceipt);
@@ -48,21 +42,6 @@ function RouteComponent() {
     }
   }, [date, customerName, driverName, fuelType, quantity, amount, purchaseType, itemsDescription]);
 
-  // const capture = () => {
-  //   if (webcamRef.current) {
-  //     const imageSrc = webcamRef.current.getScreenshot();
-  //     if (imageSrc) setReceipt(imageSrc);
-  //   }
-  // };
-
-  // const handleRetry = () => setReceipt("");
-
-  // const videoConstraints = {
-  //   height: 640,
-  //   facingMode: "environment",
-  // };
-
-  // Triggered by the "Retry" button
   const handleRetryCapture = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {
@@ -72,142 +51,70 @@ function RouteComponent() {
     }
   }
 
-  // ---------------------------------------------------------
-  // 🚀 SAME SUBMIT LOGIC FROM SIGNATURE PAGE (signature = "")
-  // ---------------------------------------------------------
-  const submitMutation = useMutation({
-    mutationFn: async () => {
-      if (!receipt) throw new Error("Please upload a receipt before submitting.");
+  // A ref guard (not just React state) closes the double-tap window: state
+  // only blocks a second click after the next re-render commits, which is a
+  // real gap on a slow device — the ref is checked synchronously.
+  const isSubmittingRef = useRef(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-      // Fleet upsert and change-notification are handled by the backend POST /api/purchase-orders.
+  const handleSubmit = async () => {
+    if (isSubmittingRef.current || !receipt) return;
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
 
-      // Use selected stationName from store, fallback to 'Rankin' if empty
-      const selectedStation = stationName || "Rankin";
+    const selectedStation = stationName || "Rankin";
 
-      const payload = {
-        source: "PO",
-        date: date ? format(date, 'yyyy-MM-dd') : format(new Date(), 'yyyy-MM-dd'),
-        stationName: selectedStation,
-        fleetCardNumber: fleetCardNumber || "",
-        poNumber: poNumber || "",
-        quantity: purchaseType === 'fuel' ? quantity : 0,
-        amount,
-        productCode: purchaseType === 'fuel' ? fuelType : 'NON-FUEL',
-        trx: "",
-        signature: "",
-        customerName,
-        driverName,
-        vehicleMakeModel: vehicleInfo,
-        licensePlate,
-        purchaseType,
-        itemsDescription: purchaseType === 'non-fuel' ? itemsDescription : '',
-      };
+    const payload = {
+      source: "PO",
+      date: date ? format(date, 'yyyy-MM-dd') : format(new Date(), 'yyyy-MM-dd'),
+      stationName: selectedStation,
+      fleetCardNumber: fleetCardNumber || "",
+      poNumber: poNumber || "",
+      quantity: purchaseType === 'fuel' ? quantity : 0,
+      amount,
+      productCode: purchaseType === 'fuel' ? fuelType : 'NON-FUEL',
+      trx: "",
+      signature: "",
+      customerName,
+      driverName,
+      vehicleMakeModel: vehicleInfo,
+      licensePlate,
+      purchaseType,
+      itemsDescription: purchaseType === 'non-fuel' ? itemsDescription : '',
+    };
 
-      // Offline: skip the network calls entirely and queue the whole submission
-      // (payload + receipt image) for the background sync loop to replay later.
-      if (!(await isActuallyOnline())) {
-        await savePendingAction({ type: "CREATE_PURCHASE_ORDER", receipt, payload, queuedAt: Date.now() });
-        return { queued: true };
-      }
+    try {
+      // Always save locally first — the ONLY awaited step here is a local
+      // IndexedDB write (sub-100ms), never a network call. This is what
+      // makes the button structurally unable to hang: there is nothing in
+      // this critical path that can be slow, stuck, or offline in the first
+      // place. See order-rec/$id.tsx for the same always-queue pattern.
+      await savePendingAction({ type: "CREATE_PURCHASE_ORDER", receipt, payload, queuedAt: Date.now() });
 
-      const authHeaders = {
-        Authorization: `Bearer ${localStorage.getItem("token")}`,
-        "X-Required-Permission": "po",
-      };
+      // Fire-and-forget: kicks off an immediate sync attempt so a
+      // genuinely-online user's PO leaves the "Pending upload" state within
+      // a couple of seconds rather than waiting for the navbar's next 15s
+      // poll — but since this is never awaited, it can never block
+      // navigation, no matter how long connectivity detection or the actual
+      // upload takes.
+      triggerBackgroundSync();
 
-      try {
-        const { filename } = await uploadBase64Image(receipt, "receipt.jpg");
-
-        const poResponse = await axios.post(
-          `${domain}/api/purchase-orders`,
-          { ...payload, receipt: filename },
-          { headers: authHeaders, timeout: 15000 }
-        );
-
-        if (poResponse.status !== 200 && poResponse.status !== 201) {
-          throw new Error("Failed to create purchase order");
-        }
-
-        return { queued: false, data: poResponse.data };
-      } catch (err: any) {
-        if (axios.isAxiosError(err) && err.response?.status === 403) {
-          navigate({ to: "/no-access" });
-          throw err;
-        }
-        // Connection dropped mid-submit (no response at all) — don't lose the
-        // entry, fall back to the offline queue instead of erroring out.
-        if (axios.isAxiosError(err) && !err.response) {
-          await savePendingAction({ type: "CREATE_PURCHASE_ORDER", receipt, payload, queuedAt: Date.now() });
-          return { queued: true };
-        }
-        throw err;
-      }
-    },
-    onSuccess: () => {
-      // No blocking alert() here on purpose — a native alert() freezes the tab
-      // (including the "Saving..." → idle repaint) until manually dismissed,
-      // which on a device with no visible dialog chrome can look identical to
-      // the submit being permanently stuck. The list page's amber "Pending
-      // sync" row is the queued-item confirmation instead.
       navigate({ to: "/po/list" });
-    },
-    onError: () => {
-      alert("Error submitting purchase order. Please try again.");
-    },
-  });
+    } catch (err) {
+      // Only a broken/unavailable IndexedDB lands here (e.g. quota
+      // exceeded, private-browsing restrictions) — genuinely rare, and
+      // there's no local queue to fall back to if local storage itself is
+      // the thing that failed.
+      console.error("Failed to save purchase order locally:", err);
+      isSubmittingRef.current = false;
+      setIsSubmitting(false);
+      alert("Error saving purchase order. Please try again.");
+    }
+  };
 
   // ---------------------------------------------------------
   // UI
   // ---------------------------------------------------------
-  // return (
-  //   <div className="p-4 border border-dashed border-gray-300 rounded-md space-y-6">
-  //     <div className="space-y-2">
-  //       <h2 className="text-lg font-bold">Capture Receipt</h2>
-  //       <div className="space-y-4">
-  //         <Webcam
-  //           ref={webcamRef}
-  //           screenshotFormat="image/jpeg"
-  //           videoConstraints={videoConstraints}
-  //           className={`border border-dashed border-gray-300 rounded-md ${receipt ? "hidden" : "block"}`}
-  //         />
-
-  //         {receipt && (
-  //           <img src={receipt} alt="Captured" className="border border-dashed border-gray-300 rounded-md" />
-  //         )}
-
-  //         {receipt ? (
-  //           <Button onClick={handleRetry} variant="secondary">
-  //             Retry
-  //           </Button>
-  //         ) : (
-  //           <Button onClick={capture} variant="destructive">
-  //             Capture
-  //           </Button>
-  //         )}
-  //       </div>
-  //     </div>
-
-  //     <hr className="border-t border-dashed border-gray-300" />
-
-  //     <div className="flex justify-between">
-  //       <Link to="/po">
-  //         <Button variant="outline">Back</Button>
-  //       </Link>
-
-  //       {/* 🚀 NEW SUBMIT BUTTON HERE */}
-  //       <Button onClick={() => submitMutation.mutate()} disabled={submitMutation.isPending}>
-  //         {submitMutation.isPending ? (
-  //           <>
-  //             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-  //             Submitting...
-  //           </>
-  //         ) : (
-  //           "Submit"
-  //         )}
-  //       </Button>
-  //     </div>
-  //   </div>
-  // );
   return (
     <div className="p-4 border border-dashed border-gray-300 rounded-md space-y-4 max-w-md mx-auto">
       <input
@@ -273,11 +180,11 @@ function RouteComponent() {
         </Link>
 
         <Button
-          onClick={() => submitMutation.mutate()}
-          disabled={submitMutation.isPending || !receipt}
+          onClick={handleSubmit}
+          disabled={isSubmitting || !receipt}
           className="flex-1 bg-green-700 hover:bg-green-800 shadow-md"
         >
-          {submitMutation.isPending ? (
+          {isSubmitting ? (
             <><Loader2 className="mr-2 h-4 w-4 animate-spin" /> Saving...</>
           ) : (
             "Finalize & Submit"


### PR DESCRIPTION
Finalize & Submit synchronously awaited isActuallyOnline() (up to ~12s worst case) and, even when that said online, still attempted a live upload + PO-create POST (up to ~30s more) before ever falling back to the offline queue. On a degraded connection this could keep the button stuck for the better part of a minute.

receipt.tsx now always saves the form + receipt photo to the local IndexedDB queue first — the only awaited step is a local write, never a network call — then fires a background sync attempt without awaiting it, and navigates immediately. Mirrors the always-queue pattern order-rec/$id.tsx already uses; the existing navbar-driven sync loop (online listener + 15s poll, already running on every authenticated page) picks the queued item up whenever connectivity allows, regardless of which module the user is in.

Also fixes a real data-loss race found while auditing the shared sync loop: it used to snapshot the queue, process it, then blanket-clear the entire IndexedDB store and re-add only the failures — any action queued by other code mid-pass (a second PO, an order-rec edit) was silently dropped. Rewrote it to delete each synced action individually by key and re-read the queue fresh every pass instead.

Also classifies sync failures as retryable (network/5xx) vs. permanent (403/409 — will never succeed no matter how many retries), so a permission error or duplicate PO number surfaces as a dismissible red "Upload failed" row on the list page instead of retrying forever in silent limbo. Renamed "Pending sync" to "Pending upload" badge text.