### PR TITLE
Normalize planogram gtins when building the match set

### DIFF
--- a/backend/utils/planogram.js
+++ b/backend/utils/planogram.js
@@ -204,12 +204,24 @@ function isOffPlanogram(item, planogramGtins, isStationSupply) {
  *
  * The null return is the "skip the check entirely" rule: callers branch on
  * truthiness, so a site without a planogram can never flag anything.
+ *
+ * Re-normalizes every stored gtin rather than trusting it's already padded.
+ * parsePlanogramWorkbook() pads to 14 on upload, but planogramKey() also pads
+ * whatever it's given, so a document written before that padding existed (or
+ * edited by hand) would carry short, unpadded gtins that silently never match
+ * a padded order-rec key. Running both sides through the same normalizeGtin()
+ * at compare time is what keeps them from drifting apart again.
  */
 async function loadPlanogramGtinSet(site) {
   const Planogram = require('../models/Planogram')
   const doc = await Planogram.findOne({ site }, { 'items.gtin': 1 }).lean()
   if (!doc || !Array.isArray(doc.items) || doc.items.length === 0) return null
-  return new Set(doc.items.map((i) => i.gtin))
+  const set = new Set()
+  for (const i of doc.items) {
+    const gtin = normalizeGtin(i.gtin)
+    if (gtin !== null) set.add(gtin)
+  }
+  return set
 }
 
 module.exports = {


### PR DESCRIPTION
loadPlanogramGtinSet() was reading items.gtin straight from the DB without running it through normalizeGtin(). The order-rec side (planogramKey) always normalizes, so a stored planogram gtin that wasn't already zero-padded to 14 digits (e.g. legacy data uploaded before the padding logic existed) would silently never match a padded order-rec key even though it's the same GTIN. This covers both the crtCode and gtin fallback paths since they share this Set.