### PR TITLE
Match planogram items on gtin first, falling back to crtCode

### DIFF
--- a/backend/__tests__/planogram.test.js
+++ b/backend/__tests__/planogram.test.js
@@ -212,26 +212,26 @@ describe('parsePlanogramWorkbook', () => {
 // ─── isOffPlanogram ───────────────────────────────────────────────────────────
 
 describe('planogramKey', () => {
-  it('prefers crtCode over gtin when the item has one', () => {
+  it('prefers gtin over crtCode when the item has both', () => {
     expect(planogramKey({ gtin: '00001911605605', crtCode: '1966850289' })).toBe(
-      '00001966850289',
+      '00001911605605',
     )
   })
 
-  it('falls back to gtin when there is no crtCode', () => {
-    for (const crtCode of ['', null, undefined]) {
-      expect(planogramKey({ gtin: '00042100008715', crtCode })).toBe('00042100008715')
+  it('falls back to crtCode when there is no gtin', () => {
+    for (const gtin of ['', null, undefined]) {
+      expect(planogramKey({ gtin, crtCode: '1966850289' })).toBe('00001966850289')
     }
   })
 
-  // A CSV that has been through Excel renders column B as "6.80085E+11" — the
-  // real digits are already gone. Falling back to the gtin is the only honest
-  // move; matching on the mangled text would flag a real product.
-  it('falls back to gtin when the crtCode is unreadable', () => {
-    expect(planogramKey({ gtin: '00042100008715', crtCode: '6.80085E+11' })).toBe(
-      '00042100008715',
+  // A CSV that has been through Excel can render column A as "6.80085E+11" —
+  // the real digits are already gone. Falling back to crtCode is the only
+  // honest move; matching on the mangled text would flag a real product.
+  it('falls back to crtCode when the gtin is unreadable', () => {
+    expect(planogramKey({ gtin: '6.80085E+11', crtCode: '1966850289' })).toBe(
+      '00001966850289',
     )
-    expect(planogramKey({ gtin: '00042100008715', crtCode: '↑' })).toBe('00042100008715')
+    expect(planogramKey({ gtin: '↑', crtCode: '1966850289' })).toBe('00001966850289')
   })
 
   it('is null only when neither code is readable', () => {
@@ -288,14 +288,14 @@ describe('isOffPlanogram', () => {
   })
 
   // The reason this feature was rebuilt. A cigarette item's gtin is the PACK
-  // barcode; the planogram lists the carton code. Comparing the gtin flagged
-  // every carton-sold product in the file.
+  // barcode; the planogram lists the carton code. Comparing the gtin alone
+  // flagged every carton-sold product in the file.
   describe('carton-sold items', () => {
     // "Putters KO LT 20": pack barcode in column A, carton code in column B of
     // the CRT row. Only the carton code is on the planogram.
     const cartonPlanogram = new Set(['00001966850289'])
 
-    it('does not flag an item whose crtCode is on the planogram', () => {
+    it('does not flag an item whose crtCode is on the planogram even though its gtin misses', () => {
       expect(
         isOffPlanogram(
           { gtin: '00001911605605', crtCode: '1966850289' },
@@ -305,7 +305,7 @@ describe('isOffPlanogram', () => {
       ).toBe(false)
     })
 
-    it('flags an item whose crtCode is absent even though its gtin would miss too', () => {
+    it('flags an item whose crtCode is also absent from the planogram', () => {
       expect(
         isOffPlanogram(
           { gtin: '00002303085388', crtCode: '23030853859' },
@@ -322,6 +322,24 @@ describe('isOffPlanogram', () => {
       expect(isOffPlanogram({ gtin: '00042100008715', crtCode: '' }, mixed, false)).toBe(
         false,
       )
+    })
+  })
+
+  // Osoyoos: Backwoods 5-packs are shelved as packs, so the planogram lists
+  // their pack gtin — but the CSV still carries a crtCode for each, from the
+  // wholesale-case sub-row. Preferring crtCode here flagged every one of them
+  // even though the pack gtin was right there on the planogram.
+  describe('pack-sold items with an incidental crtCode', () => {
+    const packPlanogram = new Set(['00071610203358']) // Backwoods Vanilla 5 PK
+
+    it('does not flag an item whose gtin is on the planogram even though its crtCode is a case code that is not', () => {
+      expect(
+        isOffPlanogram(
+          { gtin: '00071610203358', crtCode: '71610340848' },
+          packPlanogram,
+          false,
+        ),
+      ).toBe(false)
     })
   })
 

--- a/backend/utils/planogram.js
+++ b/backend/utils/planogram.js
@@ -158,26 +158,30 @@ function parsePlanogramWorkbook(buffer) {
 }
 
 /**
- * The identifier an order-rec item is matched on: crtCode when the item has a
- * readable one, otherwise gtin.
+ * The identifier an order-rec item would be matched on if only one were
+ * available: gtin when the item has a readable one, otherwise crtCode.
  *
  * The planogram's "Product ID" column is a MIXED identifier space, not one kind
  * of number. It lists whichever code identifies the form of the product that
- * actually occupies the shelf: a carton code for cigarettes sold by the carton,
- * and a plain GTIN for tins, pouches and bags. Measured against the Silver
- * Grizzly Back Wall planogram, 21 of its 60 rows are carton codes and 33 are
- * GTINs — so a rule that used either one alone would silently miss half the
- * shelf.
+ * actually occupies the shelf: a plain GTIN for anything sold as a pack, tin,
+ * pouch or bag, and a carton code for the (site-dependent) subset that's
+ * genuinely shelved by the carton — cigarettes at some sites. Which is which
+ * is a per-site, sometimes per-category fact the CSV doesn't tell us, so this
+ * is only ever a tiebreak: isOffPlanogram() below checks BOTH codes against
+ * the planogram and only uses this one key for reporting which code an
+ * unmatched item was closest to.
  *
- * The fallback direction matters. Every order-rec item has a gtin, but only
- * items with a CRT sub-row have a crtCode, and for those the gtin is the PACK
- * barcode, which the planogram never lists (it matched 0 of 46 in that sample).
- * So crtCode wins whenever it is present, and gtin covers everything else.
+ * gtin goes first because every order-rec item has one and it is the code
+ * actually printed on the shelf-facing unit; crtCode exists only for items
+ * with a CRT sub-row, and plenty of planograms (Osoyoos's Cigars category,
+ * for one — Backwoods 5-packs are shelved as packs, not cases) never list the
+ * carton code at all, so leading with crtCode there flagged every match crt
+ * could have made instead of gtin.
  */
 function planogramKey(item) {
   if (!item) return null
-  const crt = normalizeGtin(item.crtCode)
-  return crt !== null ? crt : normalizeGtin(item.gtin)
+  const gtin = normalizeGtin(item.gtin)
+  return gtin !== null ? gtin : normalizeGtin(item.crtCode)
 }
 
 /**
@@ -186,17 +190,27 @@ function planogramKey(item) {
  * Both the order-rec create path and the recheck endpoint call this, so the
  * flag written at creation can never disagree with the flag written later.
  *
+ * Checks gtin AND crtCode (when each is readable) against the planogram set
+ * and clears the flag if either is present — the two codes are matched
+ * independently rather than picking one key up front, because which one the
+ * planogram actually lists varies by site and category (see planogramKey()).
+ * A carton-sold item whose gtin is the pack barcode still needs crtCode to
+ * find its match; a pack-sold item with a stray crtCode still needs gtin to.
+ *
  * Fails open in every uncertain case: no planogram for the site, a station
  * supply, or an item with no readable code at all yield false rather than a
  * guess. An unreadable crtCode is not itself a failure — a CSV export that
- * mangled column B into "6.80085E+11" fails normalizeGtin, and the item falls
- * back to its gtin rather than being flagged on a value we could not read.
+ * mangled column B into "6.80085E+11" fails normalizeGtin, and the item is
+ * judged on gtin alone rather than being flagged on a value we could not read.
  */
 function isOffPlanogram(item, planogramGtins, isStationSupply) {
   if (!planogramGtins || isStationSupply) return false
-  const key = planogramKey(item)
-  if (key === null) return false
-  return !planogramGtins.has(key)
+  const gtin = normalizeGtin(item?.gtin)
+  const crt = normalizeGtin(item?.crtCode)
+  if (gtin === null && crt === null) return false
+  if (gtin !== null && planogramGtins.has(gtin)) return false
+  if (crt !== null && planogramGtins.has(crt)) return false
+  return true
 }
 
 /**


### PR DESCRIPTION
planogramKey() previously preferred crtCode over gtin whenever an item had a readable one. That's right for planograms that list carton-sold items by carton code, but wrong for ones that list them by pack gtin instead (e.g. Osoyoos's Cigars category: Backwoods 5-packs are shelved as packs, but the CSV still carries a crtCode from their wholesale-case sub-row). Preferring crtCode there flagged every Backwoods item as off-planogram even though its pack gtin was on the planogram.

isOffPlanogram() now checks gtin and crtCode independently against the planogram set and clears the flag if either matches, rather than picking one key up front — so carton-sold items still match on crtCode (gtin is their pack barcode and isn't listed), while pack-sold items with an incidental crtCode still match on gtin.

Verified against a real Osoyoos planogram + order rec: all 9 flagged Backwoods items now match correctly, with no change to the legitimate carton-code matches in Cigarettes.