### PR TITLE
Fix vendor search dropdown closing on Android virtual keyboard

### DIFF
--- a/frontend/src/components/custom/invoiceVendorSelect.tsx
+++ b/frontend/src/components/custom/invoiceVendorSelect.tsx
@@ -1,0 +1,135 @@
+import { useRef, useState } from "react";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+// Define EDI vendor rules:
+// - `excludedSites: []` means EDI is enabled for ALL stores.
+// - `excludedSites: ["Site A", "Site B"]` means EDI is enabled for all stores EXCEPT those listed.
+export const EDI_VENDORS_CONFIG: Record<
+  string,
+  { name: string; excludedSites: string[] }
+> = {
+  // EDI enabled for ALL stores (no exclusions)
+  "96239": { name: "Quota Core-Mark", excludedSites: [] },
+  "721": { name: "Core-Mark", excludedSites: [] },
+
+  // EDI enabled for ALL stores EXCEPT these 4 (they can manually upload)
+  "64990": {
+    name: "COCA-COLA BOTTLING LTD",
+    excludedSites: ["Oliver", "Osoyoos", "Wavers West", "Wavers East"],
+  },
+  "97290": {
+    name: "Coke Canada Bottling",
+    excludedSites: ["Oliver", "Osoyoos", "Wavers West", "Wavers East"],
+  },
+};
+
+export interface VendorData {
+  code: string;
+  name: string;
+}
+
+interface InvoiceVendorSelectProps {
+  vendors: VendorData[];
+  value: string;
+  onValueChange: (code: string) => void;
+  disabled?: boolean;
+}
+
+// Searchable vendor Select for the Upload Invoice module. Shared by
+// upload-invoice/index.tsx (create) and upload-invoice/$id.tsx (edit) so the
+// fix below only has to live in one place.
+export function InvoiceVendorSelect({
+  vendors,
+  value,
+  onValueChange,
+  disabled,
+}: InvoiceVendorSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const searchWrapperRef = useRef<HTMLDivElement>(null);
+
+  const filteredVendors = vendors.filter(
+    (v) =>
+      v.name.toLowerCase().includes(search.toLowerCase()) ||
+      v.code.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    // Radix's SelectContent attaches an unconditional window "resize"/"blur"
+    // listener for as long as the popup is open and force-closes on either
+    // (see radix-ui/primitives#2634, open/unresolved upstream — no prop to
+    // opt out). Focusing this search input to type opens the Android virtual
+    // keyboard, which resizes the visual viewport and fires exactly that
+    // "resize" event, slamming the dropdown shut mid-search. So: if Radix is
+    // asking to close while focus is still inside the search box, the user
+    // is mid-search, not dismissing anything — ignore the request. Focus
+    // moves onto the tapped SelectItem itself when the user actually picks a
+    // vendor (Radix gives items tabIndex={-1}, which real taps/clicks do
+    // focus), so a genuine selection still closes normally.
+    if (
+      !nextOpen &&
+      searchWrapperRef.current?.contains(document.activeElement)
+    ) {
+      return;
+    }
+    setOpen(nextOpen);
+    if (!nextOpen) setSearch("");
+  };
+
+  return (
+    <Select
+      value={value}
+      onValueChange={onValueChange}
+      disabled={disabled}
+      open={open}
+      onOpenChange={handleOpenChange}
+    >
+      <SelectTrigger className="w-full bg-white">
+        <SelectValue placeholder={disabled ? "Loading..." : "Select Vendor"} />
+      </SelectTrigger>
+      <SelectContent>
+        <div
+          ref={searchWrapperRef}
+          className="p-2 border-b border-slate-100 sticky top-0 bg-white z-10"
+          /* Prevent tablet touch events from triggering dropdown close */
+          onPointerDown={(e) => e.stopPropagation()}
+          onTouchStart={(e) => e.stopPropagation()}
+        >
+          <Input
+            type="text"
+            placeholder="Search name or code..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-8 text-xs"
+            onKeyDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+            onFocus={(e) => e.stopPropagation()}
+          />
+        </div>
+        <SelectGroup className="max-h-[250px] overflow-y-auto">
+          <SelectLabel>Available Vendors</SelectLabel>
+          {filteredVendors.length === 0 ? (
+            <div className="text-xs text-slate-400 text-center py-4">
+              No vendors found
+            </div>
+          ) : (
+            filteredVendors.map((v) => (
+              <SelectItem key={v.code} value={v.code}>
+                {v.name} ({v.code})
+              </SelectItem>
+            ))
+          )}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/frontend/src/routes/_navbarLayout/upload-invoice/$id.tsx
+++ b/frontend/src/routes/_navbarLayout/upload-invoice/$id.tsx
@@ -14,10 +14,14 @@ import {
   SelectContent,
   SelectGroup,
   SelectItem,
-  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  InvoiceVendorSelect,
+  EDI_VENDORS_CONFIG,
+  type VendorData,
+} from "@/components/custom/invoiceVendorSelect";
 import {
   Dialog,
   DialogContent,
@@ -33,12 +37,6 @@ import {
   AlertTriangle,
   RotateCcw,
 } from "lucide-react";
-import { EDI_VENDORS_CONFIG } from "./index";
-
-interface VendorData {
-  code: string;
-  name: string;
-}
 
 export const Route = createFileRoute("/_navbarLayout/upload-invoice/$id")({
   component: RouteComponent,
@@ -58,7 +56,6 @@ function RouteComponent() {
   const [invoiceDate, setInvoiceDate] = useState<Date | undefined>(undefined);
   const [vendorCode, setVendorCode] = useState<string>("");
   const [vendorName, setVendorName] = useState<string>("");
-  const [vendorSearch, setVendorSearch] = useState<string>("");
   const [docNumber, setDocNumber] = useState<string>("");
   const [mop, setMop] = useState<string>("");
   const [checkNumber, setCheckNumber] = useState<string>("");
@@ -84,12 +81,6 @@ function RouteComponent() {
     { value: "eft", label: "EFT" },
     { value: "credit_card", label: "Credit Card" },
   ];
-
-  const filteredVendors = vendors.filter(
-    (v) =>
-      v.name.toLowerCase().includes(vendorSearch.toLowerCase()) ||
-      v.code.toLowerCase().includes(vendorSearch.toLowerCase()),
-  );
 
   // 1. Fetch Master Vendors
   useEffect(() => {
@@ -225,7 +216,6 @@ function RouteComponent() {
 
         setVendorCode(originalCode);
         setVendorName(originalVendor?.name || "");
-        setVendorSearch("");
         return;
       }
     }
@@ -361,53 +351,12 @@ function RouteComponent() {
               <label className="text-xs font-semibold text-slate-600">
                 Vendor
               </label>
-              <Select
+              <InvoiceVendorSelect
+                vendors={vendors}
                 value={vendorCode}
                 onValueChange={handleVendorChange} // Updated from setVendorCode
                 disabled={isLoadingVendors}
-                onOpenChange={(open) => !open && setVendorSearch("")}
-              >
-                <SelectTrigger className="w-full bg-white">
-                  <SelectValue
-                    placeholder={
-                      isLoadingVendors ? "Loading..." : "Select Vendor"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  <div
-                    className="p-2 border-b border-slate-100 sticky top-0 bg-white z-10"
-                    /* Prevents tablet touch events from dismissing the dropdown */
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onTouchStart={(e) => e.stopPropagation()}
-                  >
-                    <Input
-                      type="text"
-                      placeholder="Search name or code..."
-                      value={vendorSearch}
-                      onChange={(e) => setVendorSearch(e.target.value)}
-                      className="h-8 text-xs"
-                      onKeyDown={(e) => e.stopPropagation()}
-                      onClick={(e) => e.stopPropagation()}
-                      onFocus={(e) => e.stopPropagation()}
-                    />
-                  </div>
-                  <SelectGroup className="max-h-[250px] overflow-y-auto">
-                    <SelectLabel>Available Vendors</SelectLabel>
-                    {filteredVendors.length === 0 ? (
-                      <div className="text-xs text-slate-400 text-center py-4">
-                        No vendors found
-                      </div>
-                    ) : (
-                      filteredVendors.map((v) => (
-                        <SelectItem key={v.code} value={v.code}>
-                          {v.name} ({v.code})
-                        </SelectItem>
-                      ))
-                    )}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
+              />
             </div>
 
             {/* Doc # */}

--- a/frontend/src/routes/_navbarLayout/upload-invoice/index.tsx
+++ b/frontend/src/routes/_navbarLayout/upload-invoice/index.tsx
@@ -11,10 +11,14 @@ import {
   SelectContent,
   SelectGroup,
   SelectItem,
-  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  InvoiceVendorSelect,
+  EDI_VENDORS_CONFIG,
+  type VendorData,
+} from "@/components/custom/invoiceVendorSelect";
 import {
   Dialog,
   DialogContent,
@@ -29,33 +33,6 @@ import {
   Loader2,
   AlertTriangle,
 } from "lucide-react";
-
-interface VendorData {
-  code: string;
-  name: string;
-}
-
-// Define EDI vendor rules:
-// - `excludedSites: []` means EDI is enabled for ALL stores.
-// - `excludedSites: ["Site A", "Site B"]` means EDI is enabled for all stores EXCEPT those listed.
-export const EDI_VENDORS_CONFIG: Record<
-  string,
-  { name: string; excludedSites: string[] }
-> = {
-  // EDI enabled for ALL stores (no exclusions)
-  "96239": { name: "Quota Core-Mark", excludedSites: [] },
-  "721": { name: "Core-Mark", excludedSites: [] },
-
-  // EDI enabled for ALL stores EXCEPT these 4 (they can manually upload)
-  "64990": {
-    name: "COCA-COLA BOTTLING LTD",
-    excludedSites: ["Oliver", "Osoyoos", "Wavers West", "Wavers East"],
-  },
-  "97290": {
-    name: "Coke Canada Bottling",
-    excludedSites: ["Oliver", "Osoyoos", "Wavers West", "Wavers East"],
-  },
-};
 
 export const Route = createFileRoute("/_navbarLayout/upload-invoice/")({
   component: RouteComponent,
@@ -74,7 +51,6 @@ function RouteComponent() {
   const [invoiceDate, setInvoiceDate] = useState<Date | undefined>(new Date());
   const [vendorCode, setVendorCode] = useState<string>("");
   const [vendorName, setVendorName] = useState<string>("");
-  const [vendorSearch, setVendorSearch] = useState<string>("");
   const [docNumber, setDocNumber] = useState<string>("");
   const [mop, setMop] = useState<string>("");
   const [checkNumber, setCheckNumber] = useState<string>("");
@@ -99,13 +75,6 @@ function RouteComponent() {
     { value: "eft", label: "EFT" },
     { value: "credit_card", label: "Credit Card" },
   ];
-
-  // Filter vendors based on search input (Code or Name)
-  const filteredVendors = vendors.filter(
-    (v) =>
-      v.name.toLowerCase().includes(vendorSearch.toLowerCase()) ||
-      v.code.toLowerCase().includes(vendorSearch.toLowerCase()),
-  );
 
   // Fetch Live SQL Vendors on Mount
   useEffect(() => {
@@ -205,7 +174,6 @@ function RouteComponent() {
         // Clear vendor field selection
         setVendorCode("");
         setVendorName("");
-        setVendorSearch("");
         return;
       }
     }
@@ -330,53 +298,12 @@ function RouteComponent() {
               <label className="text-xs font-semibold text-slate-600">
                 Vendor
               </label>
-              <Select
+              <InvoiceVendorSelect
+                vendors={vendors}
                 value={vendorCode}
                 onValueChange={handleVendorChange}
                 disabled={isLoadingVendors}
-                onOpenChange={(open) => !open && setVendorSearch("")}
-              >
-                <SelectTrigger className="w-full bg-white">
-                  <SelectValue
-                    placeholder={
-                      isLoadingVendors ? "Loading..." : "Select Vendor"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  <div
-                    className="p-2 border-b border-slate-100 sticky top-0 bg-white z-10"
-                    /* Prevent tablet touch events from triggering dropdown close */
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onTouchStart={(e) => e.stopPropagation()}
-                  >
-                    <Input
-                      type="text"
-                      placeholder="Search name or code..."
-                      value={vendorSearch}
-                      onChange={(e) => setVendorSearch(e.target.value)}
-                      className="h-8 text-xs"
-                      onKeyDown={(e) => e.stopPropagation()}
-                      onClick={(e) => e.stopPropagation()}
-                      onFocus={(e) => e.stopPropagation()}
-                    />
-                  </div>
-                  <SelectGroup className="max-h-[250px] overflow-y-auto">
-                    <SelectLabel>Available Vendors</SelectLabel>
-                    {filteredVendors.length === 0 ? (
-                      <div className="text-xs text-slate-400 text-center py-4">
-                        No vendors found
-                      </div>
-                    ) : (
-                      filteredVendors.map((v) => (
-                        <SelectItem key={v.code} value={v.code}>
-                          {v.name} ({v.code})
-                        </SelectItem>
-                      ))
-                    )}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
+              />
             </div>
 
             {/* Field 3: Doc # */}


### PR DESCRIPTION
Radix's SelectContent attaches an unconditional window resize/blur listener for as long as the popup is open and force-closes on either, with no prop to opt out (radix-ui/primitives#2634, open upstream). Focusing the vendor search input opens the Android on-screen keyboard, which resizes the viewport and fires that resize event, closing the dropdown mid-search. This is a separate mechanism from the touch outside-click issue fixed in ab04ebf3, so that fix couldn't catch it.

Extract the vendor search-Select (previously duplicated between upload-invoice/index.tsx and $id.tsx) into a shared InvoiceVendorSelect component that controls the Select's open state itself and ignores a resize/blur-triggered close while focus is still inside the search box. A real vendor pick still closes normally since Radix moves focus onto the tapped item.